### PR TITLE
style(dashboard): show empty state instead of blank when no tabs open

### DIFF
--- a/extension/dashboard-runtime.js
+++ b/extension/dashboard-runtime.js
@@ -1326,8 +1326,8 @@ async function renderStaticDashboard() {
 
   if (domainGroups.length > 0 && openTabsSection) {
     if (openTabsSectionTitle) openTabsSectionTitle.textContent = 'Open tabs';
-    openTabsSectionCount.innerHTML = `<span class="section-summary">${realTabs.length} tab${realTabs.length !== 1 ? 's' : ''} across ${domainGroups.length} group${domainGroups.length !== 1 ? 's' : ''}</span><button class="action-btn close-tabs section-action" type="button" data-action="close-all-open-tabs">${ICONS.close} Close all tabs</button>`;
-    openTabsMissionsEl.innerHTML = domainGroups.map(g => renderDomainCard(g)).join('');
+    if (openTabsSectionCount) openTabsSectionCount.innerHTML = `<span class="section-summary">${realTabs.length} tab${realTabs.length !== 1 ? 's' : ''} across ${domainGroups.length} group${domainGroups.length !== 1 ? 's' : ''}</span><button class="action-btn close-tabs section-action" type="button" data-action="close-all-open-tabs">${ICONS.close} Close all tabs</button>`;
+    if (openTabsMissionsEl) openTabsMissionsEl.innerHTML = domainGroups.map(g => renderDomainCard(g)).join('');
     if (openTabsGroupNav) {
       openTabsGroupNav.innerHTML = renderGroupNavArea(domainGroups);
       openTabsGroupNav.style.display = 'flex';
@@ -1338,7 +1338,19 @@ async function renderStaticDashboard() {
       openTabsGroupNav.innerHTML = '';
       openTabsGroupNav.style.display = 'none';
     }
-    openTabsSection.style.display = 'none';
+    openTabsSection.style.display = 'block';
+    if (openTabsMissionsEl) openTabsMissionsEl.innerHTML = `
+      <div class="missions-empty-state">
+        <div class="empty-checkmark">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+          </svg>
+        </div>
+        <div class="empty-title">Inbox zero, but for tabs.</div>
+        <div class="empty-subtitle">You're free.</div>
+      </div>
+    `;
+    if (openTabsSectionCount) openTabsSectionCount.textContent = '0 domains';
   }
 
   // --- Footer stats ---

--- a/extension/dashboard-runtime.js
+++ b/extension/dashboard-runtime.js
@@ -1339,17 +1339,7 @@ async function renderStaticDashboard() {
       openTabsGroupNav.style.display = 'none';
     }
     openTabsSection.style.display = 'block';
-    if (openTabsMissionsEl) openTabsMissionsEl.innerHTML = `
-      <div class="missions-empty-state">
-        <div class="empty-checkmark">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
-          </svg>
-        </div>
-        <div class="empty-title">Inbox zero, but for tabs.</div>
-        <div class="empty-subtitle">You're free.</div>
-      </div>
-    `;
+    if (openTabsMissionsEl) openTabsMissionsEl.innerHTML = renderMissionsEmptyState();
     if (openTabsSectionCount) openTabsSectionCount.textContent = '0 domains';
   }
 

--- a/extension/index.html
+++ b/extension/index.html
@@ -303,7 +303,7 @@
 
 <!-- Personal config (gitignored) — defines LOCAL_LANDING_PAGE_PATTERNS etc. -->
 <!-- If the file doesn't exist, that's fine — app.js uses sensible defaults. -->
-<script src="config.local.js" onerror="/* no personal config, that's fine */"></script>
+<script src="config.local.js"></script>
 
 <!-- Shared icon helpers — real favicons first, then graceful fallbacks -->
 <script src="icon-utils.js"></script>

--- a/extension/style.css
+++ b/extension/style.css
@@ -2114,6 +2114,11 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   letter-spacing: 0.3px;
 }
 
+.missions-empty-state {
+  width: 100%;
+  min-height: 380px;
+}
+
 
 /* ================================================================
    UPDATE BANNER

--- a/extension/style.css
+++ b/extension/style.css
@@ -2114,11 +2114,6 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   letter-spacing: 0.3px;
 }
 
-.missions-empty-state {
-  width: 100%;
-  min-height: 380px;
-}
-
 
 /* ================================================================
    UPDATE BANNER

--- a/extension/ui-helpers.js
+++ b/extension/ui-helpers.js
@@ -130,14 +130,8 @@ function showToast(message) {
   setTimeout(() => toast.classList.remove('visible'), 2500);
 }
 
-function checkAndShowEmptyState() {
-  const missionsEl = document.getElementById('openTabsMissions');
-  if (!missionsEl) return;
-
-  const remaining = missionsEl.querySelectorAll('.mission-card:not(.closing)').length;
-  if (remaining > 0) return;
-
-  missionsEl.innerHTML = `
+function renderMissionsEmptyState() {
+  return `
     <div class="missions-empty-state">
       <div class="empty-checkmark">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
@@ -148,6 +142,16 @@ function checkAndShowEmptyState() {
       <div class="empty-subtitle">You're free.</div>
     </div>
   `;
+}
+
+function checkAndShowEmptyState() {
+  const missionsEl = document.getElementById('openTabsMissions');
+  if (!missionsEl) return;
+
+  const remaining = missionsEl.querySelectorAll('.mission-card:not(.closing)').length;
+  if (remaining > 0) return;
+
+  missionsEl.innerHTML = renderMissionsEmptyState();
 
   const countEl = document.getElementById('openTabsSectionCount');
   if (countEl) countEl.textContent = '0 domains';


### PR DESCRIPTION
## Change

  - 显示空状态而非空白区域：打开浏览器进入新标签页时显示空状态
  - extract renderMissionsEmptyState to ui-helpers
  - 修复浏览器控制台报错，移除了违反 CSP 的内联 onerror 处理器
  
## 预览
<img width="740" height="597" alt="截屏2026-04-26 12 57 07" src="https://github.com/user-attachments/assets/1827ff21-37a3-4f7d-9e77-6497bb989e41" />
