### PR TITLE
feature:sync chrome tabs group

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -8,9 +8,17 @@ const {
   ready: appI18nReady,
 } = globalThis.TabHarborI18n || {};
 
+const {
+  TabHarborConfigReady: appConfigReady,
+} = globalThis;
+
 async function initializeApp() {
   if (!appMountDashboardRuntime) {
     throw new Error('Tab Harbor dashboard runtime is unavailable');
+  }
+
+  if (appConfigReady && typeof appConfigReady.then === 'function') {
+    await appConfigReady;
   }
 
   if (appI18nReady && typeof appI18nReady.then === 'function') {

--- a/extension/chrome-tab-groups-import.js
+++ b/extension/chrome-tab-groups-import.js
@@ -1,0 +1,165 @@
+'use strict';
+
+(function attachChromeTabGroupImport(globalScope) {
+  const {
+    addSessionGroup,
+    normalizeSessionGroups,
+  } = globalScope.TabOutSessionGroups || {};
+
+  const EMPTY_META = {
+    entries: [],
+  };
+
+  function normalizeChromeImportedGroupMeta(input) {
+    const entries = Array.isArray(input?.entries)
+      ? input.entries
+        .filter(entry => entry && entry.sessionGroupId)
+        .map(entry => ({
+          sessionGroupId: String(entry.sessionGroupId),
+          chromeGroupId: entry.chromeGroupId == null ? null : Number(entry.chromeGroupId),
+          windowId: entry.windowId == null ? 0 : Number(entry.windowId),
+          title: String(entry.title || 'Group').trim() || 'Group',
+          color: String(entry.color || 'grey'),
+        }))
+      : [];
+
+    return { entries };
+  }
+
+  function buildMetaSignature(entry) {
+    return [
+      String(entry.windowId ?? 0),
+      String(entry.title || 'Group').trim() || 'Group',
+      String(entry.color || 'grey'),
+    ].join('::');
+  }
+
+  function buildUniqueGroupName(baseName, groups, excludeGroupId = '') {
+    const fallbackName = String(baseName || 'Group').trim() || 'Group';
+    const lowerFallback = fallbackName.toLowerCase();
+    const takenNames = new Set(
+      (groups || [])
+        .filter(group => group && group.id !== excludeGroupId)
+        .map(group => String(group.name || '').trim().toLowerCase())
+        .filter(Boolean)
+    );
+
+    if (!takenNames.has(lowerFallback)) return fallbackName;
+
+    let suffix = 2;
+    while (takenNames.has(`${lowerFallback} ${suffix}`)) suffix++;
+    return `${fallbackName} ${suffix}`;
+  }
+
+  function reconcileChromeTabGroupImports({
+    currentState,
+    importedMeta,
+    nativeGroups,
+  }) {
+    if (typeof normalizeSessionGroups !== 'function' || typeof addSessionGroup !== 'function') {
+      throw new Error('Session group helpers are unavailable');
+    }
+
+    const normalizedState = normalizeSessionGroups(currentState);
+    const normalizedMeta = normalizeChromeImportedGroupMeta(importedMeta);
+    const managedIds = new Set(normalizedMeta.entries.map(entry => entry.sessionGroupId));
+    const sessionGroupIds = new Set(normalizedState.groups.map(group => group.id));
+
+    let groups = normalizedState.groups.filter(group => !managedIds.has(group.id) || sessionGroupIds.has(group.id));
+    let assignments = {};
+    for (const [tabId, groupId] of Object.entries(normalizedState.assignments)) {
+      if (managedIds.has(groupId)) continue;
+      assignments[tabId] = groupId;
+    }
+
+    const metaByChromeGroupId = new Map();
+    const metaBySignature = new Map();
+    for (const entry of normalizedMeta.entries) {
+      if (!sessionGroupIds.has(entry.sessionGroupId)) continue;
+      if (entry.chromeGroupId != null) metaByChromeGroupId.set(entry.chromeGroupId, entry);
+      metaBySignature.set(buildMetaSignature(entry), entry);
+    }
+
+    const nextMetaEntries = [];
+    const mappings = [];
+
+    for (const nativeGroup of (nativeGroups || [])) {
+      const chromeGroupId = nativeGroup?.chromeGroupId == null ? null : Number(nativeGroup.chromeGroupId);
+      const windowId = nativeGroup?.windowId == null ? 0 : Number(nativeGroup.windowId);
+      const title = String(nativeGroup?.title || 'Group').trim() || 'Group';
+      const color = String(nativeGroup?.color || 'grey');
+      const tabIds = Array.isArray(nativeGroup?.tabIds)
+        ? nativeGroup.tabIds.filter(tabId => tabId != null).map(tabId => String(tabId))
+        : [];
+      if (tabIds.length === 0) continue;
+
+      const signature = buildMetaSignature({ windowId, title, color });
+      const existingMeta = (chromeGroupId != null && metaByChromeGroupId.get(chromeGroupId))
+        || metaBySignature.get(signature)
+        || null;
+
+      let sessionGroupId = existingMeta?.sessionGroupId || '';
+      let groupIndex = groups.findIndex(group => group.id === sessionGroupId);
+
+      if (groupIndex === -1) {
+        const uniqueName = buildUniqueGroupName(title, groups);
+        const created = addSessionGroup({ groups, assignments }, uniqueName);
+        groups = created.state.groups;
+        assignments = created.state.assignments;
+        sessionGroupId = created.group.id;
+        groupIndex = groups.findIndex(group => group.id === sessionGroupId);
+      } else {
+        const uniqueName = buildUniqueGroupName(title, groups, sessionGroupId);
+        if (groups[groupIndex].name !== uniqueName) {
+          groups = groups.map(group => group.id === sessionGroupId
+            ? { ...group, name: uniqueName }
+            : group);
+        }
+      }
+
+      for (const tabId of tabIds) {
+        assignments[tabId] = sessionGroupId;
+      }
+
+      if (chromeGroupId != null) {
+        mappings.push({
+          virtualGroupKey: `__session_group__:${sessionGroupId}`,
+          windowId,
+          chromeGroupId,
+        });
+      }
+
+      nextMetaEntries.push({
+        sessionGroupId,
+        chromeGroupId,
+        windowId,
+        title,
+        color,
+      });
+    }
+
+    const activeManagedIds = new Set(nextMetaEntries.map(entry => entry.sessionGroupId));
+    groups = groups.filter(group => !managedIds.has(group.id) || activeManagedIds.has(group.id));
+    assignments = Object.fromEntries(
+      Object.entries(assignments).filter(([, groupId]) => !managedIds.has(groupId) || activeManagedIds.has(groupId))
+    );
+
+    return {
+      state: normalizeSessionGroups({ groups, assignments }),
+      importedMeta: normalizeChromeImportedGroupMeta({ entries: nextMetaEntries }),
+      mappings,
+    };
+  }
+
+  const api = {
+    EMPTY_META,
+    normalizeChromeImportedGroupMeta,
+    reconcileChromeTabGroupImports,
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+
+  globalScope.TabOutChromeTabGroupImport = api;
+})(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/extension/chrome-tab-groups-import.test.js
+++ b/extension/chrome-tab-groups-import.test.js
@@ -1,0 +1,151 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+require('./session-groups.js');
+require('./chrome-tab-groups-import.js');
+
+const {
+  reconcileChromeTabGroupImports,
+} = globalThis.TabOutChromeTabGroupImport;
+
+test('reconcileChromeTabGroupImports creates managed session groups for native Chrome groups', () => {
+  const result = reconcileChromeTabGroupImports({
+    currentState: { groups: [], assignments: {} },
+    importedMeta: { entries: [] },
+    nativeGroups: [
+      {
+        chromeGroupId: 101,
+        windowId: 1,
+        title: 'Work',
+        color: 'blue',
+        tabIds: [11, 12],
+      },
+    ],
+  });
+
+  assert.equal(result.state.groups.length, 1);
+  assert.equal(result.state.groups[0].name, 'Work');
+  assert.equal(result.state.assignments['11'], result.state.groups[0].id);
+  assert.equal(result.state.assignments['12'], result.state.groups[0].id);
+  assert.deepEqual(result.importedMeta.entries, [
+    {
+      sessionGroupId: result.state.groups[0].id,
+      chromeGroupId: 101,
+      windowId: 1,
+      title: 'Work',
+      color: 'blue',
+    },
+  ]);
+  assert.deepEqual(result.mappings, [
+    {
+      virtualGroupKey: `__session_group__:${result.state.groups[0].id}`,
+      windowId: 1,
+      chromeGroupId: 101,
+    },
+  ]);
+});
+
+test('reconcileChromeTabGroupImports reuses existing managed group and updates its title', () => {
+  const result = reconcileChromeTabGroupImports({
+    currentState: {
+      groups: [
+        { id: 'session-1', name: 'Old Work', createdAt: '2026-04-28T00:00:00.000Z' },
+      ],
+      assignments: { '11': 'session-1' },
+    },
+    importedMeta: {
+      entries: [
+        {
+          sessionGroupId: 'session-1',
+          chromeGroupId: 101,
+          windowId: 1,
+          title: 'Old Work',
+          color: 'blue',
+        },
+      ],
+    },
+    nativeGroups: [
+      {
+        chromeGroupId: 101,
+        windowId: 1,
+        title: 'Work',
+        color: 'red',
+        tabIds: [22],
+      },
+    ],
+  });
+
+  assert.equal(result.state.groups.length, 1);
+  assert.equal(result.state.groups[0].id, 'session-1');
+  assert.equal(result.state.groups[0].name, 'Work');
+  assert.deepEqual(result.state.assignments, { '22': 'session-1' });
+  assert.equal(result.importedMeta.entries[0].color, 'red');
+});
+
+test('reconcileChromeTabGroupImports removes stale managed groups when Chrome groups disappear', () => {
+  const result = reconcileChromeTabGroupImports({
+    currentState: {
+      groups: [
+        { id: 'managed-1', name: 'Imported', createdAt: '2026-04-28T00:00:00.000Z' },
+        { id: 'manual-1', name: 'Manual', createdAt: '2026-04-28T00:00:00.000Z' },
+      ],
+      assignments: {
+        '11': 'managed-1',
+        '22': 'manual-1',
+      },
+    },
+    importedMeta: {
+      entries: [
+        {
+          sessionGroupId: 'managed-1',
+          chromeGroupId: 101,
+          windowId: 1,
+          title: 'Imported',
+          color: 'blue',
+        },
+      ],
+    },
+    nativeGroups: [],
+  });
+
+  assert.deepEqual(result.state.groups.map(group => group.id), ['manual-1']);
+  assert.deepEqual(result.state.assignments, { '22': 'manual-1' });
+  assert.deepEqual(result.importedMeta.entries, []);
+});
+
+test('reconcileChromeTabGroupImports matches persisted metadata when Chrome group ids change after restart', () => {
+  const result = reconcileChromeTabGroupImports({
+    currentState: {
+      groups: [
+        { id: 'session-1', name: 'Work', createdAt: '2026-04-28T00:00:00.000Z' },
+      ],
+      assignments: {},
+    },
+    importedMeta: {
+      entries: [
+        {
+          sessionGroupId: 'session-1',
+          chromeGroupId: 101,
+          windowId: 3,
+          title: 'Work',
+          color: 'blue',
+        },
+      ],
+    },
+    nativeGroups: [
+      {
+        chromeGroupId: 808,
+        windowId: 3,
+        title: 'Work',
+        color: 'blue',
+        tabIds: [33],
+      },
+    ],
+  });
+
+  assert.equal(result.state.groups[0].id, 'session-1');
+  assert.equal(result.state.assignments['33'], 'session-1');
+  assert.equal(result.importedMeta.entries[0].chromeGroupId, 808);
+});

--- a/extension/chrome-tab-groups-sync.js
+++ b/extension/chrome-tab-groups-sync.js
@@ -1,0 +1,244 @@
+'use strict';
+
+(function attachChromeTabGroups(globalScope) {
+
+  const STORAGE_KEY = 'chromeTabGroupsEnabled';
+
+  let cachedEnabled = false;
+  let chromeGroupMap = {};
+  let importMode = false;
+
+  const GROUP_COLORS = ['grey', 'red', 'green', 'pink', 'purple', 'cyan', 'orange'];
+
+  function getGroupTitle(group) {
+    if (group.domain === '__landing-pages__') return 'Homepages';
+    if (group.label) return group.label;
+    try {
+      const hostname = group.domain.replace(/^__session_group__:/, '');
+      return friendlyDomain(hostname);
+    } catch {
+      return group.domain;
+    }
+  }
+
+  function assignGroupColor(groupKey, index) {
+    if (groupKey.startsWith('__session_group__:')) return 'blue';
+    if (groupKey === '__landing-pages__') return 'yellow';
+    return GROUP_COLORS[index % GROUP_COLORS.length];
+  }
+
+  async function loadChromeTabGroupsSetting() {
+    try {
+      const stored = await chrome.storage.local.get(STORAGE_KEY);
+      cachedEnabled = Boolean(stored[STORAGE_KEY]);
+    } catch {
+      cachedEnabled = false;
+    }
+    return cachedEnabled;
+  }
+
+  async function saveChromeTabGroupsSetting(enabled) {
+    cachedEnabled = Boolean(enabled);
+    await chrome.storage.local.set({ [STORAGE_KEY]: cachedEnabled });
+    return cachedEnabled;
+  }
+
+  function isChromeApiAvailable() {
+    return typeof chrome !== 'undefined' &&
+      chrome.tabs && typeof chrome.tabs.group === 'function' &&
+      chrome.tabGroups && typeof chrome.tabGroups.update === 'function';
+  }
+
+  async function ungroupTabs(tabIds) {
+    if (!tabIds || tabIds.length === 0) return;
+    try {
+      await chrome.tabs.ungroup(tabIds);
+    } catch {
+      // Tab may have been closed already
+    }
+  }
+
+  async function removeAllChromeGroups() {
+    const allTrackedTabIds = [];
+    for (const windowMap of Object.values(chromeGroupMap)) {
+      for (const chromeGroupId of Object.values(windowMap)) {
+        try {
+          const group = await chrome.tabGroups.get(chromeGroupId);
+          if (group) {
+            const tabs = await chrome.tabs.query({ groupId: chromeGroupId });
+            allTrackedTabIds.push(...tabs.map(t => t.id).filter(Boolean));
+          }
+        } catch {
+          // Group may have been removed externally
+        }
+      }
+    }
+    if (allTrackedTabIds.length > 0) {
+      await ungroupTabs(allTrackedTabIds);
+    }
+    chromeGroupMap = {};
+  }
+
+  async function syncChromeTabGroups(domainGroups) {
+    if (!cachedEnabled) {
+      await removeAllChromeGroups();
+      return;
+    }
+
+    if (!isChromeApiAvailable()) return;
+
+    // Build desired state: { groupKey: { windowId: [tabIds] } }
+    const desired = {};
+    for (const group of domainGroups) {
+      const groupKey = group.domain;
+      for (const tab of (group.tabs || [])) {
+        if (tab.id == null) continue;
+        const windowId = tab.windowId != null ? tab.windowId : 0;
+        if (!desired[groupKey]) desired[groupKey] = {};
+        if (!desired[groupKey][windowId]) desired[groupKey][windowId] = [];
+        desired[groupKey][windowId].push(tab.id);
+      }
+    }
+
+    // Collect current Chrome tab groups to check existence
+    let currentGroups = [];
+    try {
+      currentGroups = await chrome.tabGroups.query({});
+    } catch {}
+
+    const validGroupIds = new Set(currentGroups.map(g => g.id));
+
+    // Remove orphaned Chrome groups (tracked but no longer needed)
+    const neededKeys = new Set(Object.keys(desired));
+    for (const [groupKey, windowMap] of Object.entries(chromeGroupMap)) {
+      if (!neededKeys.has(groupKey)) {
+        for (const chromeGroupId of Object.values(windowMap)) {
+          if (validGroupIds.has(chromeGroupId)) {
+            try {
+              const tabs = await chrome.tabs.query({ groupId: chromeGroupId });
+              await ungroupTabs(tabs.map(t => t.id).filter(Boolean));
+            } catch {}
+          }
+        }
+        delete chromeGroupMap[groupKey];
+      }
+    }
+
+    // Process each virtual group
+    let colorIndex = 0;
+    for (const [groupKey, windowMap] of Object.entries(desired)) {
+      const groupColor = assignGroupColor(groupKey, colorIndex);
+      const group = domainGroups.find(g => g.domain === groupKey);
+      const title = group ? getGroupTitle(group) : groupKey;
+      if (!groupKey.startsWith('__session_group__:')) {
+        colorIndex++;
+      }
+
+      for (const [windowIdStr, tabIds] of Object.entries(windowMap)) {
+        if (tabIds.length === 0) continue;
+
+        const windowId = Number(windowIdStr);
+        let chromeGroupId = chromeGroupMap[groupKey]?.[windowId];
+
+        // Reuse existing Chrome group if still valid
+        if (chromeGroupId != null && !validGroupIds.has(chromeGroupId)) {
+          chromeGroupId = null;
+        }
+
+        if (chromeGroupId == null) {
+          // In import mode, only reuse existing groups — don't create new ones
+          if (importMode) continue;
+
+          // Create new group
+          try {
+            chromeGroupId = await chrome.tabs.group({ tabIds });
+          } catch {
+            // Some tabs may have valid IDs but fail grouping; try one by one
+            for (const tabId of tabIds) {
+              try {
+                const gid = await chrome.tabs.group({ tabIds: tabId });
+                if (chromeGroupId == null) chromeGroupId = gid;
+              } catch {}
+            }
+          }
+
+          if (chromeGroupId != null) {
+            try {
+              await chrome.tabGroups.update(chromeGroupId, { title, color: groupColor });
+            } catch {}
+          }
+        } else {
+          // Move tabs into existing group
+          try {
+            await chrome.tabs.group({ groupId: chromeGroupId, tabIds });
+          } catch {}
+        }
+
+        // Track the mapping
+        if (chromeGroupId != null) {
+          if (!chromeGroupMap[groupKey]) chromeGroupMap[groupKey] = {};
+          chromeGroupMap[groupKey][windowId] = chromeGroupId;
+        }
+      }
+    }
+  }
+
+  function resetChromeGroupState() {
+    chromeGroupMap = {};
+    cachedEnabled = false;
+  }
+
+  function isChromeTabGroupsEnabled() {
+    return cachedEnabled;
+  }
+
+  function getChromeGroupCount() {
+    return Object.keys(chromeGroupMap).length;
+  }
+
+  function populateChromeGroupMap(mappings) {
+    for (const { virtualGroupKey, windowId, chromeGroupId } of mappings) {
+      if (!chromeGroupMap[virtualGroupKey]) chromeGroupMap[virtualGroupKey] = {};
+      chromeGroupMap[virtualGroupKey][windowId] = chromeGroupId;
+    }
+  }
+
+  async function queryExistingChromeGroups() {
+    try {
+      return await chrome.tabGroups.query({});
+    } catch {
+      return [];
+    }
+  }
+
+  function setImportMode(enabled) {
+    importMode = Boolean(enabled);
+  }
+
+  function isImportMode() {
+    return importMode;
+  }
+
+  const api = {
+    loadChromeTabGroupsSetting,
+    saveChromeTabGroupsSetting,
+    syncChromeTabGroups,
+    resetChromeGroupState,
+    isChromeTabGroupsEnabled,
+    getChromeGroupCount,
+    populateChromeGroupMap,
+    queryExistingChromeGroups,
+    setImportMode,
+    isImportMode,
+    STORAGE_KEY,
+    assignGroupColor,
+    getGroupTitle,
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+
+  globalScope.TabOutChromeTabGroups = api;
+
+})(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/extension/chrome-tab-groups-sync.js
+++ b/extension/chrome-tab-groups-sync.js
@@ -8,8 +8,54 @@
   let cachedEnabled = false;
   let chromeGroupMap = {};
   let importMode = false;
+  let chromeEventMuteUntil = 0;
+  let chromeListenersAttached = false;
+  const chromeGroupSubscribers = new Set();
 
   const GROUP_COLORS = ['grey', 'red', 'green', 'pink', 'purple', 'cyan', 'orange'];
+
+  function muteChromeGroupEvents(durationMs = 250) {
+    chromeEventMuteUntil = Math.max(chromeEventMuteUntil, Date.now() + durationMs);
+  }
+
+  function shouldIgnoreChromeEvent() {
+    return !cachedEnabled || Date.now() < chromeEventMuteUntil;
+  }
+
+  function notifyChromeGroupSubscribers(event) {
+    if (shouldIgnoreChromeEvent()) return;
+    for (const subscriber of chromeGroupSubscribers) {
+      try {
+        subscriber(event);
+      } catch {}
+    }
+  }
+
+  function attachChromeListeners() {
+    if (chromeListenersAttached || typeof chrome === 'undefined') return;
+
+    const eventBindings = [
+      [chrome.tabGroups?.onCreated, group => notifyChromeGroupSubscribers({ source: 'tabGroups.onCreated', group })],
+      [chrome.tabGroups?.onUpdated, (groupId, changeInfo) => notifyChromeGroupSubscribers({ source: 'tabGroups.onUpdated', groupId, changeInfo })],
+      [chrome.tabGroups?.onRemoved, group => notifyChromeGroupSubscribers({ source: 'tabGroups.onRemoved', group })],
+      [chrome.tabs?.onAttached, (tabId, attachInfo) => notifyChromeGroupSubscribers({ source: 'tabs.onAttached', tabId, attachInfo })],
+      [chrome.tabs?.onCreated, tab => notifyChromeGroupSubscribers({ source: 'tabs.onCreated', tab })],
+      [chrome.tabs?.onDetached, (tabId, detachInfo) => notifyChromeGroupSubscribers({ source: 'tabs.onDetached', tabId, detachInfo })],
+      [chrome.tabs?.onRemoved, (tabId, removeInfo) => notifyChromeGroupSubscribers({ source: 'tabs.onRemoved', tabId, removeInfo })],
+      [chrome.tabs?.onUpdated, (tabId, changeInfo, tab) => {
+        if (changeInfo?.groupId == null) return;
+        notifyChromeGroupSubscribers({ source: 'tabs.onUpdated', tabId, changeInfo, tab });
+      }],
+    ];
+
+    for (const [eventSource, listener] of eventBindings) {
+      if (eventSource && typeof eventSource.addListener === 'function') {
+        eventSource.addListener(listener);
+      }
+    }
+
+    chromeListenersAttached = true;
+  }
 
   function getGroupTitle(group) {
     if (group.domain === '__landing-pages__') return 'Homepages';
@@ -105,6 +151,7 @@
   }
 
   async function removeAllChromeGroups() {
+    muteChromeGroupEvents();
     const allTrackedTabIds = [];
     for (const windowMap of Object.values(chromeGroupMap)) {
       for (const chromeGroupId of Object.values(windowMap)) {
@@ -127,6 +174,7 @@
   }
 
   async function syncChromeTabGroups(domainGroups) {
+    muteChromeGroupEvents();
     await loadPersistedChromeGroupMap();
 
     if (!cachedEnabled) {
@@ -240,6 +288,7 @@
     chromeGroupMap = {};
     cachedEnabled = false;
     importMode = false;
+    chromeEventMuteUntil = 0;
     try {
       await chrome.storage.local.remove(META_PERSIST_KEY);
     } catch {}
@@ -269,12 +318,50 @@
     }
   }
 
+  async function syncChromeTabGroupExpansionForTab(tab) {
+    if (!cachedEnabled || !isChromeApiAvailable()) return;
+
+    const targetGroupId = Number(tab?.groupId);
+    const targetWindowId = Number(tab?.windowId);
+    if (!Number.isFinite(targetGroupId) || targetGroupId < 0) return;
+    if (!Number.isFinite(targetWindowId)) return;
+
+    let groups = [];
+    try {
+      groups = await chrome.tabGroups.query({});
+    } catch {
+      return;
+    }
+
+    const groupsInWindow = groups.filter(group => Number(group?.windowId) === targetWindowId);
+    muteChromeGroupEvents();
+
+    for (const group of groupsInWindow) {
+      const nextCollapsed = group.id !== targetGroupId;
+      if (Boolean(group.collapsed) === nextCollapsed) continue;
+      try {
+        await chrome.tabGroups.update(group.id, { collapsed: nextCollapsed });
+      } catch {}
+    }
+  }
+
   function setImportMode(enabled) {
     importMode = Boolean(enabled);
   }
 
   function isImportMode() {
     return importMode;
+  }
+
+  function subscribeToChromeTabGroupChanges(listener) {
+    if (typeof listener !== 'function') {
+      return () => {};
+    }
+    attachChromeListeners();
+    chromeGroupSubscribers.add(listener);
+    return () => {
+      chromeGroupSubscribers.delete(listener);
+    };
   }
 
   const api = {
@@ -286,8 +373,10 @@
     getChromeGroupCount,
     populateChromeGroupMap,
     queryExistingChromeGroups,
+    syncChromeTabGroupExpansionForTab,
     setImportMode,
     isImportMode,
+    subscribeToChromeTabGroupChanges,
     STORAGE_KEY,
     assignGroupColor,
     getGroupTitle,

--- a/extension/chrome-tab-groups-sync.js
+++ b/extension/chrome-tab-groups-sync.js
@@ -3,6 +3,7 @@
 (function attachChromeTabGroups(globalScope) {
 
   const STORAGE_KEY = 'chromeTabGroupsEnabled';
+  const MAP_PERSIST_KEY = 'chromeTabGroupsMap';
 
   let cachedEnabled = false;
   let chromeGroupMap = {};
@@ -34,6 +35,7 @@
     } catch {
       cachedEnabled = false;
     }
+    await loadPersistedChromeGroupMap();
     return cachedEnabled;
   }
 
@@ -41,6 +43,21 @@
     cachedEnabled = Boolean(enabled);
     await chrome.storage.local.set({ [STORAGE_KEY]: cachedEnabled });
     return cachedEnabled;
+  }
+
+  async function persistChromeGroupMap() {
+    try {
+      await chrome.storage.local.set({ [MAP_PERSIST_KEY]: chromeGroupMap });
+    } catch {}
+  }
+
+  async function loadPersistedChromeGroupMap() {
+    try {
+      const result = await chrome.storage.local.get(MAP_PERSIST_KEY);
+      if (result[MAP_PERSIST_KEY]) {
+        chromeGroupMap = result[MAP_PERSIST_KEY];
+      }
+    } catch {}
   }
 
   function isChromeApiAvailable() {
@@ -77,9 +94,12 @@
       await ungroupTabs(allTrackedTabIds);
     }
     chromeGroupMap = {};
+    await persistChromeGroupMap();
   }
 
   async function syncChromeTabGroups(domainGroups) {
+    await loadPersistedChromeGroupMap();
+
     if (!cachedEnabled) {
       await removeAllChromeGroups();
       return;
@@ -156,8 +176,11 @@
             // Some tabs may have valid IDs but fail grouping; try one by one
             for (const tabId of tabIds) {
               try {
-                const gid = await chrome.tabs.group({ tabIds: tabId });
-                if (chromeGroupId == null) chromeGroupId = gid;
+                if (chromeGroupId == null) {
+                  chromeGroupId = await chrome.tabs.group({ tabIds: tabId });
+                } else {
+                  await chrome.tabs.group({ groupId: chromeGroupId, tabIds: tabId });
+                }
               } catch {}
             }
           }
@@ -181,11 +204,16 @@
         }
       }
     }
+    await persistChromeGroupMap();
   }
 
-  function resetChromeGroupState() {
+  async function resetChromeGroupState() {
     chromeGroupMap = {};
     cachedEnabled = false;
+    importMode = false;
+    try {
+      await chrome.storage.local.remove(MAP_PERSIST_KEY);
+    } catch {}
   }
 
   function isChromeTabGroupsEnabled() {
@@ -196,11 +224,12 @@
     return Object.keys(chromeGroupMap).length;
   }
 
-  function populateChromeGroupMap(mappings) {
+  async function populateChromeGroupMap(mappings) {
     for (const { virtualGroupKey, windowId, chromeGroupId } of mappings) {
       if (!chromeGroupMap[virtualGroupKey]) chromeGroupMap[virtualGroupKey] = {};
       chromeGroupMap[virtualGroupKey][windowId] = chromeGroupId;
     }
+    await persistChromeGroupMap();
   }
 
   async function queryExistingChromeGroups() {

--- a/extension/chrome-tab-groups-sync.js
+++ b/extension/chrome-tab-groups-sync.js
@@ -3,7 +3,7 @@
 (function attachChromeTabGroups(globalScope) {
 
   const STORAGE_KEY = 'chromeTabGroupsEnabled';
-  const MAP_PERSIST_KEY = 'chromeTabGroupsMap';
+  const META_PERSIST_KEY = 'chromeTabGroupsMeta';
 
   let cachedEnabled = false;
   let chromeGroupMap = {};
@@ -47,16 +47,45 @@
 
   async function persistChromeGroupMap() {
     try {
-      await chrome.storage.local.set({ [MAP_PERSIST_KEY]: chromeGroupMap });
+      // Save group metadata (title, color) instead of raw groupIds,
+      // since Chrome tab group IDs are only stable within a session.
+      const meta = {};
+      for (const [groupKey, windowMap] of Object.entries(chromeGroupMap)) {
+        for (const chromeGroupId of Object.values(windowMap)) {
+          try {
+            const group = await chrome.tabGroups.get(chromeGroupId);
+            if (group && !meta[groupKey]) {
+              meta[groupKey] = { title: group.title, color: group.color };
+            }
+          } catch {}
+        }
+      }
+      await chrome.storage.local.set({ [META_PERSIST_KEY]: meta });
     } catch {}
   }
 
   async function loadPersistedChromeGroupMap() {
     try {
-      const result = await chrome.storage.local.get(MAP_PERSIST_KEY);
-      if (result[MAP_PERSIST_KEY]) {
-        chromeGroupMap = result[MAP_PERSIST_KEY];
+      const result = await chrome.storage.local.get(META_PERSIST_KEY);
+      const meta = result[META_PERSIST_KEY];
+      if (!meta || Object.keys(meta).length === 0) return;
+
+      const currentGroups = await chrome.tabGroups.query({});
+      const reconciled = {};
+
+      for (const [groupKey, info] of Object.entries(meta)) {
+        // Match by title + color — the values we control. After restart,
+        // Chrome assigns new groupIds, but our groups retain their title/color.
+        const match = currentGroups.find(g =>
+          g.title === info.title && g.color === info.color
+        );
+        if (match) {
+          if (!reconciled[groupKey]) reconciled[groupKey] = {};
+          reconciled[groupKey][match.windowId] = match.id;
+        }
       }
+
+      chromeGroupMap = reconciled;
     } catch {}
   }
 
@@ -212,7 +241,7 @@
     cachedEnabled = false;
     importMode = false;
     try {
-      await chrome.storage.local.remove(MAP_PERSIST_KEY);
+      await chrome.storage.local.remove(META_PERSIST_KEY);
     } catch {}
   }
 

--- a/extension/chrome-tab-groups-sync.test.js
+++ b/extension/chrome-tab-groups-sync.test.js
@@ -1,0 +1,324 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// Mock chrome APIs before loading the module
+const mockStorage = {};
+globalThis.chrome = {
+  storage: {
+    local: {
+      get: async (keys) => {
+        const key = Array.isArray(keys) ? keys[0] : keys;
+        return { [key]: mockStorage[key] ?? undefined };
+      },
+      set: async (items) => {
+        Object.assign(mockStorage, items);
+      },
+    },
+  },
+  tabs: {
+    group: async (opts) => 0,
+    ungroup: async () => {},
+    query: async (opts) => opts?.groupId != null ? [] : [],
+  },
+  tabGroups: {
+    query: async () => [],
+    update: async () => {},
+    get: async () => null,
+  },
+};
+
+require('./chrome-tab-groups-sync.js');
+
+const {
+  loadChromeTabGroupsSetting,
+  saveChromeTabGroupsSetting,
+  syncChromeTabGroups,
+  resetChromeGroupState,
+  isChromeTabGroupsEnabled,
+  getChromeGroupCount,
+  populateChromeGroupMap,
+  queryExistingChromeGroups,
+  setImportMode,
+  assignGroupColor,
+  getGroupTitle,
+} = globalThis.TabOutChromeTabGroups;
+
+test('assignGroupColor returns blue for session groups', () => {
+  assert.equal(assignGroupColor('__session_group__:g1', 0), 'blue');
+  assert.equal(assignGroupColor('__session_group__:g2', 5), 'blue');
+});
+
+test('assignGroupColor returns yellow for landing pages', () => {
+  assert.equal(assignGroupColor('__landing-pages__', 0), 'yellow');
+  assert.equal(assignGroupColor('__landing-pages__', 3), 'yellow');
+});
+
+test('assignGroupColor cycles through colors for domain groups', () => {
+  const colors = ['grey', 'red', 'green', 'pink', 'purple', 'cyan', 'orange'];
+  colors.forEach((expected, i) => {
+    assert.equal(assignGroupColor('example.com', i), expected);
+  });
+  // Cycles back
+  assert.equal(assignGroupColor('test.com', 7), colors[0]);
+});
+
+test('getGroupTitle returns friendly domain for regular groups', () => {
+  const group = { domain: 'github.com', tabs: [] };
+  const title = getGroupTitle(group);
+  assert.equal(typeof title, 'string');
+  assert.ok(title.length > 0);
+});
+
+test('getGroupTitle uses label for custom groups', () => {
+  const group = { domain: 'custom-key', label: 'Work', tabs: [] };
+  assert.equal(getGroupTitle(group), 'Work');
+});
+
+test('getGroupTitle returns Homepages for landing pages', () => {
+  const group = { domain: '__landing-pages__', tabs: [] };
+  assert.equal(getGroupTitle(group), 'Homepages');
+});
+
+test('loadChromeTabGroupsSetting returns false by default', async () => {
+  resetChromeGroupState();
+  delete mockStorage.chromeTabGroupsEnabled;
+  const result = await loadChromeTabGroupsSetting();
+  assert.equal(result, false);
+  assert.equal(isChromeTabGroupsEnabled(), false);
+});
+
+test('saveChromeTabGroupsSetting persists and updates cached state', async () => {
+  resetChromeGroupState();
+  const saved = await saveChromeTabGroupsSetting(true);
+  assert.equal(saved, true);
+  assert.equal(isChromeTabGroupsEnabled(), true);
+  assert.equal(mockStorage.chromeTabGroupsEnabled, true);
+
+  const loaded = await loadChromeTabGroupsSetting();
+  assert.equal(loaded, true);
+});
+
+test('saveChromeTabGroupsSetting toggles off correctly', async () => {
+  resetChromeGroupState();
+  await saveChromeTabGroupsSetting(true);
+  assert.equal(isChromeTabGroupsEnabled(), true);
+  await saveChromeTabGroupsSetting(false);
+  assert.equal(isChromeTabGroupsEnabled(), false);
+  assert.equal(mockStorage.chromeTabGroupsEnabled, false);
+});
+
+test('syncChromeTabGroups removes groups when disabled', async () => {
+  resetChromeGroupState();
+  await saveChromeTabGroupsSetting(false);
+
+  const groups = [
+    { domain: 'github.com', tabs: [{ id: 1, windowId: 1, url: 'https://github.com' }] },
+  ];
+
+  // Should not throw when disabled
+  await syncChromeTabGroups(groups);
+  assert.equal(getChromeGroupCount(), 0);
+});
+
+test('syncChromeTabGroups creates groups when enabled', async () => {
+  resetChromeGroupState();
+  let groupCallCount = 0;
+  let updateCallArgs = [];
+
+  globalThis.chrome.tabs.group = async (opts) => {
+    groupCallCount++;
+    return 100 + groupCallCount;
+  };
+
+  globalThis.chrome.tabGroups.update = async (id, opts) => {
+    updateCallArgs.push({ id, ...opts });
+  };
+
+  globalThis.chrome.tabGroups.query = async () => [];
+  globalThis.chrome.tabs.query = async (opts) => [];
+
+  await saveChromeTabGroupsSetting(true);
+
+  const groups = [
+    { domain: 'github.com', tabs: [{ id: 1, windowId: 1, url: 'https://github.com' }] },
+    { domain: 'example.com', tabs: [{ id: 2, windowId: 1, url: 'https://example.com' }] },
+  ];
+
+  await syncChromeTabGroups(groups);
+
+  assert.equal(groupCallCount, 2);
+  assert.equal(updateCallArgs.length, 2);
+  assert.equal(updateCallArgs[0].color, 'grey');
+  assert.equal(updateCallArgs[1].color, 'red');
+  assert.equal(getChromeGroupCount(), 2);
+});
+
+test('syncChromeTabGroups handles tabs in different windows', async () => {
+  resetChromeGroupState();
+  let groupCallCount = 0;
+
+  globalThis.chrome.tabs.group = async (opts) => {
+    groupCallCount++;
+    return 200 + groupCallCount;
+  };
+
+  globalThis.chrome.tabGroups.update = async () => {};
+  globalThis.chrome.tabGroups.query = async () => [];
+  globalThis.chrome.tabs.query = async (opts) => [];
+
+  await saveChromeTabGroupsSetting(true);
+
+  const groups = [
+    {
+      domain: 'github.com',
+      tabs: [
+        { id: 1, windowId: 1, url: 'https://github.com' },
+        { id: 3, windowId: 2, url: 'https://github.com/other' },
+      ],
+    },
+  ];
+
+  await syncChromeTabGroups(groups);
+
+  // Should create 1 group for each window → 2 total chrome.tabs.group calls
+  assert.equal(groupCallCount, 2);
+});
+
+test('syncChromeTabGroups cleans up when disabled after being enabled', async () => {
+  resetChromeGroupState();
+  let ungroupCalls = [];
+
+  globalThis.chrome.tabs.ungroup = async (tabIds) => {
+    ungroupCalls.push(tabIds);
+  };
+
+  globalThis.chrome.tabs.group = async (opts) => 300;
+  globalThis.chrome.tabGroups.update = async () => {};
+  globalThis.chrome.tabGroups.query = async () => [];
+  globalThis.chrome.tabs.query = async (opts) => [];
+
+  await saveChromeTabGroupsSetting(true);
+
+  const groups = [
+    { domain: 'test.com', tabs: [{ id: 10, windowId: 1, url: 'https://test.com' }] },
+  ];
+
+  await syncChromeTabGroups(groups);
+  assert.ok(getChromeGroupCount() > 0);
+
+  // Now disable
+  await saveChromeTabGroupsSetting(false);
+  await syncChromeTabGroups(groups);
+
+  assert.equal(getChromeGroupCount(), 0);
+});
+
+test('syncChromeTabGroups handles empty tabs gracefully', async () => {
+  resetChromeGroupState();
+  await saveChromeTabGroupsSetting(true);
+  await syncChromeTabGroups([]);
+  assert.equal(getChromeGroupCount(), 0);
+});
+
+test('syncChromeTabGroups handles groups with no tabs', async () => {
+  resetChromeGroupState();
+  await saveChromeTabGroupsSetting(true);
+  await syncChromeTabGroups([{ domain: 'empty.com', tabs: [] }]);
+  assert.equal(getChromeGroupCount(), 0);
+});
+
+test('populateChromeGroupMap adds mappings to internal state', () => {
+  resetChromeGroupState();
+  populateChromeGroupMap([
+    { virtualGroupKey: 'github.com', windowId: 1, chromeGroupId: 101 },
+    { virtualGroupKey: 'github.com', windowId: 2, chromeGroupId: 102 },
+  ]);
+  assert.equal(getChromeGroupCount(), 1);
+});
+
+test('queryExistingChromeGroups returns groups from chrome.tabGroups.query', async () => {
+  globalThis.chrome.tabGroups.query = async () => [
+    { id: 1, title: 'Work', color: 'blue' },
+    { id: 2, title: 'Research', color: 'red' },
+  ];
+  const groups = await queryExistingChromeGroups();
+  assert.equal(groups.length, 2);
+  assert.equal(groups[0].title, 'Work');
+});
+
+test('syncChromeTabGroups reuses chromeGroupMap populated by populateChromeGroupMap', async () => {
+  resetChromeGroupState();
+  let lastGroupCall = null;
+
+  globalThis.chrome.tabs.group = async (opts) => {
+    lastGroupCall = opts;
+    return 500;
+  };
+  globalThis.chrome.tabGroups.update = async () => {};
+  globalThis.chrome.tabGroups.query = async () => [{ id: 500, title: 'GitHub', color: 'grey' }];
+  globalThis.chrome.tabs.query = async (opts) => [];
+
+  await saveChromeTabGroupsSetting(true);
+
+  // Pre-populate the mapping (simulating "pull from Chrome groups" scenario)
+  populateChromeGroupMap([
+    { virtualGroupKey: 'github.com', windowId: 1, chromeGroupId: 500 },
+  ]);
+
+  const groups = [
+    { domain: 'github.com', tabs: [{ id: 10, windowId: 1, url: 'https://github.com' }] },
+  ];
+
+  await syncChromeTabGroups(groups);
+
+  // Should have reused the existing group — called with groupId (reuse path), not tabIds (create path)
+  assert.equal(lastGroupCall.groupId, 500);
+  assert.deepEqual(lastGroupCall.tabIds, [10]);
+});
+
+test('syncChromeTabGroups in import mode skips creating new groups for ungrouped tabs', async () => {
+  resetChromeGroupState();
+  let createCalls = 0;
+  let reuseCalls = 0;
+
+  globalThis.chrome.tabs.group = async (opts) => {
+    if (opts.groupId != null) {
+      reuseCalls++;
+      return opts.groupId;
+    }
+    createCalls++;
+    return 600 + createCalls;
+  };
+  globalThis.chrome.tabGroups.update = async () => {};
+  globalThis.chrome.tabGroups.query = async () => [{ id: 500, title: 'Work', color: 'blue' }];
+  globalThis.chrome.tabs.query = async (opts) => [];
+
+  await saveChromeTabGroupsSetting(true);
+
+  // Simulate import: populate chromeGroupMap with existing Chrome groups
+  populateChromeGroupMap([
+    { virtualGroupKey: '__session_group__:g1', windowId: 1, chromeGroupId: 500 },
+  ]);
+
+  // Enable import mode: only reuse, don't create
+  setImportMode(true);
+
+  const groups = [
+    { domain: '__session_group__:g1', label: 'Work', tabs: [{ id: 1, windowId: 1, url: 'https://a.com' }] },
+    { domain: 'github.com', tabs: [{ id: 5, windowId: 1, url: 'https://github.com' }] },
+  ];
+
+  await syncChromeTabGroups(groups);
+
+  // Work group reused existing Chrome group
+  assert.equal(reuseCalls, 1);
+  // github.com was SKIPPED (import mode, no matching Chrome group)
+  assert.equal(createCalls, 0);
+
+  // Disable import mode and sync again — now github.com should get a new group
+  setImportMode(false);
+  await syncChromeTabGroups(groups);
+  assert.equal(createCalls, 1);
+});

--- a/extension/chrome-tab-groups-sync.test.js
+++ b/extension/chrome-tab-groups-sync.test.js
@@ -3,6 +3,24 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
+function createEventEmitter() {
+  const listeners = new Set();
+  return {
+    addListener(listener) {
+      listeners.add(listener);
+    },
+    removeListener(listener) {
+      listeners.delete(listener);
+    },
+    hasListener(listener) {
+      return listeners.has(listener);
+    },
+    emit(...args) {
+      for (const listener of listeners) listener(...args);
+    },
+  };
+}
+
 // Mock chrome APIs before loading the module
 const mockStorage = {};
 globalThis.chrome = {
@@ -21,11 +39,19 @@ globalThis.chrome = {
     group: async (opts) => 0,
     ungroup: async () => {},
     query: async (opts) => opts?.groupId != null ? [] : [],
+    onAttached: createEventEmitter(),
+    onCreated: createEventEmitter(),
+    onDetached: createEventEmitter(),
+    onRemoved: createEventEmitter(),
+    onUpdated: createEventEmitter(),
   },
   tabGroups: {
     query: async () => [],
     update: async () => {},
     get: async () => null,
+    onCreated: createEventEmitter(),
+    onRemoved: createEventEmitter(),
+    onUpdated: createEventEmitter(),
   },
 };
 
@@ -35,12 +61,14 @@ const {
   loadChromeTabGroupsSetting,
   saveChromeTabGroupsSetting,
   syncChromeTabGroups,
+  syncChromeTabGroupExpansionForTab,
   resetChromeGroupState,
   isChromeTabGroupsEnabled,
   getChromeGroupCount,
   populateChromeGroupMap,
   queryExistingChromeGroups,
   setImportMode,
+  subscribeToChromeTabGroupChanges,
   assignGroupColor,
   getGroupTitle,
 } = globalThis.TabOutChromeTabGroups;
@@ -321,4 +349,58 @@ test('syncChromeTabGroups in import mode skips creating new groups for ungrouped
   setImportMode(false);
   await syncChromeTabGroups(groups);
   assert.equal(createCalls, 1);
+});
+
+test('subscribeToChromeTabGroupChanges notifies on external Chrome group changes', async () => {
+  resetChromeGroupState();
+  await saveChromeTabGroupsSetting(true);
+
+  const events = [];
+  const unsubscribe = subscribeToChromeTabGroupChanges(event => {
+    events.push(event);
+  });
+
+  globalThis.chrome.tabGroups.onUpdated.emit(501, { title: 'Work' });
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].source, 'tabGroups.onUpdated');
+
+  unsubscribe();
+});
+
+test('syncChromeTabGroupExpansionForTab expands target group and collapses sibling groups in same window', async () => {
+  resetChromeGroupState();
+  await saveChromeTabGroupsSetting(true);
+
+  const updateCalls = [];
+  globalThis.chrome.tabGroups.query = async () => [
+    { id: 101, windowId: 1, collapsed: true },
+    { id: 102, windowId: 1, collapsed: false },
+    { id: 103, windowId: 2, collapsed: false },
+  ];
+  globalThis.chrome.tabGroups.update = async (id, opts) => {
+    updateCalls.push({ id, ...opts });
+  };
+
+  await syncChromeTabGroupExpansionForTab({ groupId: 101, windowId: 1 });
+
+  assert.deepEqual(updateCalls, [
+    { id: 101, collapsed: false },
+    { id: 102, collapsed: true },
+  ]);
+});
+
+test('syncChromeTabGroupExpansionForTab skips work when Chrome sync is disabled', async () => {
+  resetChromeGroupState();
+  await saveChromeTabGroupsSetting(false);
+
+  let queryCount = 0;
+  globalThis.chrome.tabGroups.query = async () => {
+    queryCount++;
+    return [];
+  };
+
+  await syncChromeTabGroupExpansionForTab({ groupId: 101, windowId: 1 });
+
+  assert.equal(queryCount, 0);
 });

--- a/extension/config-loader.js
+++ b/extension/config-loader.js
@@ -1,0 +1,17 @@
+'use strict';
+
+(function attachOptionalLocalConfig(globalScope) {
+  if (globalScope.TabHarborConfigReady && typeof globalScope.TabHarborConfigReady.then === 'function') {
+    return;
+  }
+
+  globalScope.TabHarborConfigReady = new Promise(resolve => {
+    const script = document.createElement('script');
+    script.src = 'config.local.js';
+    script.async = false;
+    script.dataset.tabHarborOptionalConfig = 'true';
+    script.onload = () => resolve();
+    script.onerror = () => resolve();
+    document.head.appendChild(script);
+  });
+})(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/extension/config.js
+++ b/extension/config.js
@@ -1,0 +1,9 @@
+'use strict';
+
+// Checked-in defaults. Private overrides can extend these via config.local.js.
+globalThis.LOCAL_LANDING_PAGE_PATTERNS = Array.isArray(globalThis.LOCAL_LANDING_PAGE_PATTERNS)
+  ? globalThis.LOCAL_LANDING_PAGE_PATTERNS
+  : [];
+globalThis.LOCAL_CUSTOM_GROUPS = Array.isArray(globalThis.LOCAL_CUSTOM_GROUPS)
+  ? globalThis.LOCAL_CUSTOM_GROUPS
+  : [];

--- a/extension/dashboard-runtime.js
+++ b/extension/dashboard-runtime.js
@@ -42,6 +42,16 @@ const {
 } = globalThis.TabOutDeferredTriggerPosition || {};
 
 const {
+  loadChromeTabGroupsSetting,
+  saveChromeTabGroupsSetting,
+  syncChromeTabGroups,
+  isChromeTabGroupsEnabled,
+  populateChromeGroupMap,
+  queryExistingChromeGroups,
+  setImportMode,
+} = globalThis.TabOutChromeTabGroups || {};
+
+const {
   reorderSubsetByIds,
 } = globalThis.TabOutListOrder || {};
 
@@ -77,6 +87,7 @@ let draggedPageChipId = '';
 let draggedPageChipEl = null;
 let pageChipDragState = null;
 let pageChipPlaceholderEl = null;
+let chromeTabGroupsEnabled = false;
 
 function reorderVisibleItemsByIds(items, orderIds, includeItem) {
   if (reorderSubsetByIds) {
@@ -1142,6 +1153,13 @@ function renderGroupNavArea(groups) {
             value="14"
           >
         </div>
+        <div class="theme-menu-section">
+          <label class="theme-menu-toggle-label">
+            <input type="checkbox" data-action="toggle-chrome-tab-groups"${chromeTabGroupsEnabled ? ' checked' : ''}>
+            <span class="theme-menu-toggle-slider"></span>
+            <span class="theme-menu-label">Chrome tab groups</span>
+          </label>
+        </div>
         <input type="file" id="themeBackgroundInput" accept="image/*" hidden>
       </div>
     </div>`;
@@ -1356,6 +1374,9 @@ async function renderStaticDashboard() {
 
 async function renderDashboard() {
   await renderStaticDashboard();
+  if (typeof syncChromeTabGroups === 'function') {
+    await syncChromeTabGroups(domainGroups);
+  }
 }
 
 function handleIconError(imgEl, fallbackUrl) {
@@ -1544,6 +1565,58 @@ document.addEventListener('click', async (e) => {
     await saveGroupOrder(nextState);
     await renderDashboard();
     showToast(nextState.pinEnabled ? 'Pinned current order' : 'Pin order turned off');
+    return;
+  }
+
+  if (action === 'toggle-chrome-tab-groups') {
+    e.stopPropagation();
+    const nextEnabled = !isChromeTabGroupsEnabled();
+
+    if (nextEnabled && typeof queryExistingChromeGroups === 'function' && typeof populateChromeGroupMap === 'function') {
+      const existingGroups = await queryExistingChromeGroups();
+      if (existingGroups.length > 0) {
+        let state = normalizeSessionGroups(sessionGroupsState);
+        const mappings = [];
+        for (const chromeGroup of existingGroups) {
+          const tabs = await chrome.tabs.query({ groupId: chromeGroup.id }).catch(() => []);
+          const tabIds = tabs.map(t => t.id).filter(Boolean);
+          if (tabIds.length === 0) continue;
+          const name = chromeGroup.title || 'Group';
+          let group;
+          try {
+            const result = addSessionGroup(state, name);
+            state = result.state;
+            group = result.group;
+          } catch {
+            group = state.groups.find(g => g.name === name);
+          }
+          if (group) {
+            for (const tabId of tabIds) {
+              state = assignTabToSessionGroup(state, tabId, group.id);
+            }
+            const uniqueWindows = new Set(tabs.map(t => t.windowId));
+            for (const windowId of uniqueWindows) {
+              mappings.push({
+                virtualGroupKey: `__session_group__:${group.id}`,
+                windowId,
+                chromeGroupId: chromeGroup.id,
+              });
+            }
+          }
+        }
+        if (mappings.length > 0) {
+          await saveSessionGroups(state);
+          populateChromeGroupMap(mappings);
+          if (typeof setImportMode === 'function') setImportMode(true);
+        }
+      }
+    }
+
+    await saveChromeTabGroupsSetting(nextEnabled);
+    chromeTabGroupsEnabled = nextEnabled;
+    await renderDashboard();
+    if (typeof setImportMode === 'function') setImportMode(false);
+    showToast(nextEnabled ? 'Chrome tab groups on' : 'Chrome tab groups off');
     return;
   }
 
@@ -2277,6 +2350,9 @@ document.addEventListener('submit', async (e) => {
    ---------------------------------------------------------------- */
 async function initializeDashboardRuntime() {
   await loadThemePreferences();
+  if (typeof loadChromeTabGroupsSetting === 'function') {
+    chromeTabGroupsEnabled = await loadChromeTabGroupsSetting();
+  }
   await renderDashboard();
   updateBackToTopVisibility();
 }

--- a/extension/dashboard-runtime.js
+++ b/extension/dashboard-runtime.js
@@ -265,7 +265,7 @@ function updateGroupNavButtonIcon(groupKey) {
   const button = document.querySelector(`.group-nav-button[data-group-id="${CSS.escape(String(groupKey))}"]`);
   if (!group || !button || !runtimeGetGroupIcon) return;
 
-  const label = group.domain === '__landing-pages__' ? 'Homepages' : (group.label || friendlyDomain(group.domain));
+  const label = group.domain === '__landing-pages__' ? (runtimeT ? runtimeT('homepagesLabel') : 'Homepages') : (group.label || friendlyDomain(group.domain));
   const orderedGroup = {
     ...group,
     tabs: getOrderedUniqueTabsForGroup(group),
@@ -1081,7 +1081,7 @@ function renderDomainCard(group) {
       <div class="mission-content">
         <div class="mission-top">
           <div class="mission-heading">
-            <span class="mission-name">${isLanding ? 'Homepages' : (group.label || friendlyDomain(group.domain))}</span>
+            <span class="mission-name">${isLanding ? (runtimeT ? runtimeT('homepagesLabel') : 'Homepages') : (group.label || friendlyDomain(group.domain))}</span>
             ${tabBadge}
             ${dupeBadge}
           </div>
@@ -1100,7 +1100,7 @@ function renderDomainCard(group) {
 function renderGroupNav(group) {
   const stableId = getStableGroupId(group.domain);
   const isLanding = group.domain === '__landing-pages__';
-  const label = isLanding ? 'Homepages' : (group.label || friendlyDomain(group.domain));
+  const label = isLanding ? (runtimeT ? runtimeT('homepagesLabel') : 'Homepages') : (group.label || friendlyDomain(group.domain));
   const orderedGroup = {
     ...group,
     tabs: getOrderedUniqueTabsForGroup(group),
@@ -1184,9 +1184,9 @@ function renderGroupNavArea(groups) {
         </div>
         <div class="theme-menu-section">
           <label class="theme-menu-toggle-label">
-            <input type="checkbox" data-action="toggle-chrome-tab-groups"${chromeTabGroupsEnabled ? ' checked' : ''}>
+            <input type="checkbox" data-action="toggle-chrome-tab-groups"${chromeTabGroupsEnabled ? ' checked' : ''} aria-label="${runtimeT ? runtimeT('chromeTabGroupsLabel') : 'Chrome tab groups'}">
             <span class="theme-menu-toggle-slider"></span>
-            <span class="theme-menu-label">Chrome tab groups</span>
+            <span class="theme-menu-label">${runtimeT ? runtimeT('chromeTabGroupsLabel') : 'Chrome tab groups'}</span>
           </label>
         </div>
         <input type="file" id="themeBackgroundInput" accept="image/*" hidden>
@@ -1666,7 +1666,7 @@ document.addEventListener('click', async (e) => {
     chromeTabGroupsEnabled = nextEnabled;
     await renderDashboard();
     if (typeof setImportMode === 'function') setImportMode(false);
-    showToast(nextEnabled ? 'Chrome tab groups on' : 'Chrome tab groups off');
+    showToast(nextEnabled ? (runtimeT ? runtimeT('toastChromeTabGroupsOn') : 'Chrome tab groups on') : (runtimeT ? runtimeT('toastChromeTabGroupsOff') : 'Chrome tab groups off'));
     return;
   }
 
@@ -1874,7 +1874,7 @@ document.addEventListener('click', async (e) => {
     if (idx !== -1) domainGroups.splice(idx, 1);
 
     const groupLabel = group.domain === '__landing-pages__'
-      ? 'Homepages'
+      ? (runtimeT ? runtimeT('homepagesLabel') : 'Homepages')
       : (group.label || friendlyDomain(group.domain));
     const tabsWord = runtimeT
       ? (urls.length === 1 ? runtimeT('tabsWordSingular') : runtimeT('tabsWordPlural'))

--- a/extension/dashboard-runtime.js
+++ b/extension/dashboard-runtime.js
@@ -51,11 +51,163 @@ const {
   loadChromeTabGroupsSetting,
   saveChromeTabGroupsSetting,
   syncChromeTabGroups,
+  syncChromeTabGroupExpansionForTab,
   isChromeTabGroupsEnabled,
   populateChromeGroupMap,
   queryExistingChromeGroups,
   setImportMode,
+  subscribeToChromeTabGroupChanges,
 } = globalThis.TabOutChromeTabGroups || {};
+
+const {
+  setImageFallbackAttributes: runtimeSetImageFallbackAttributes,
+} = globalThis;
+
+function fallbackNormalizeChromeImportedGroupMeta(input) {
+  const entries = Array.isArray(input?.entries)
+    ? input.entries
+      .filter(entry => entry && entry.sessionGroupId)
+      .map(entry => ({
+        sessionGroupId: String(entry.sessionGroupId),
+        chromeGroupId: entry.chromeGroupId == null ? null : Number(entry.chromeGroupId),
+        windowId: entry.windowId == null ? 0 : Number(entry.windowId),
+        title: String(entry.title || 'Group').trim() || 'Group',
+        color: String(entry.color || 'grey'),
+      }))
+    : [];
+
+  return { entries };
+}
+
+function fallbackBuildChromeImportSignature(entry) {
+  return [
+    String(entry.windowId ?? 0),
+    String(entry.title || 'Group').trim() || 'Group',
+    String(entry.color || 'grey'),
+  ].join('::');
+}
+
+function fallbackBuildChromeImportName(baseName, groups, excludeGroupId = '') {
+  const fallbackName = String(baseName || 'Group').trim() || 'Group';
+  const takenNames = new Set(
+    (groups || [])
+      .filter(group => group && group.id !== excludeGroupId)
+      .map(group => String(group.name || '').trim().toLowerCase())
+      .filter(Boolean)
+  );
+  if (!takenNames.has(fallbackName.toLowerCase())) return fallbackName;
+
+  let suffix = 2;
+  while (takenNames.has(`${fallbackName.toLowerCase()} ${suffix}`)) suffix++;
+  return `${fallbackName} ${suffix}`;
+}
+
+function fallbackReconcileChromeTabGroupImports({
+  currentState,
+  importedMeta,
+  nativeGroups,
+}) {
+  const normalizedState = normalizeSessionGroups(currentState);
+  const normalizedMeta = fallbackNormalizeChromeImportedGroupMeta(importedMeta);
+  const managedIds = new Set(normalizedMeta.entries.map(entry => entry.sessionGroupId));
+  const sessionGroupIds = new Set(normalizedState.groups.map(group => group.id));
+
+  let groups = normalizedState.groups.slice();
+  let assignments = {};
+  for (const [tabId, groupId] of Object.entries(normalizedState.assignments)) {
+    if (managedIds.has(groupId)) continue;
+    assignments[tabId] = groupId;
+  }
+
+  const metaByChromeGroupId = new Map();
+  const metaBySignature = new Map();
+  for (const entry of normalizedMeta.entries) {
+    if (!sessionGroupIds.has(entry.sessionGroupId)) continue;
+    if (entry.chromeGroupId != null) metaByChromeGroupId.set(entry.chromeGroupId, entry);
+    metaBySignature.set(fallbackBuildChromeImportSignature(entry), entry);
+  }
+
+  const nextMetaEntries = [];
+  const mappings = [];
+
+  for (const nativeGroup of (nativeGroups || [])) {
+    const chromeGroupId = nativeGroup?.chromeGroupId == null ? null : Number(nativeGroup.chromeGroupId);
+    const windowId = nativeGroup?.windowId == null ? 0 : Number(nativeGroup.windowId);
+    const title = String(nativeGroup?.title || 'Group').trim() || 'Group';
+    const color = String(nativeGroup?.color || 'grey');
+    const tabIds = Array.isArray(nativeGroup?.tabIds)
+      ? nativeGroup.tabIds.filter(tabId => tabId != null).map(tabId => String(tabId))
+      : [];
+    if (!tabIds.length) continue;
+
+    const signature = fallbackBuildChromeImportSignature({ windowId, title, color });
+    const existingMeta = (chromeGroupId != null && metaByChromeGroupId.get(chromeGroupId))
+      || metaBySignature.get(signature)
+      || null;
+
+    let sessionGroupId = existingMeta?.sessionGroupId || '';
+    let groupIndex = groups.findIndex(group => group.id === sessionGroupId);
+
+    if (groupIndex === -1) {
+      const created = addSessionGroup({ groups, assignments }, fallbackBuildChromeImportName(title, groups));
+      groups = created.state.groups;
+      assignments = created.state.assignments;
+      sessionGroupId = created.group.id;
+      groupIndex = groups.findIndex(group => group.id === sessionGroupId);
+    } else {
+      const nextName = fallbackBuildChromeImportName(title, groups, sessionGroupId);
+      if (groups[groupIndex].name !== nextName) {
+        groups = groups.map(group => group.id === sessionGroupId
+          ? { ...group, name: nextName }
+          : group);
+      }
+    }
+
+    for (const tabId of tabIds) {
+      assignments[tabId] = sessionGroupId;
+    }
+
+    if (chromeGroupId != null) {
+      mappings.push({
+        virtualGroupKey: `__session_group__:${sessionGroupId}`,
+        windowId,
+        chromeGroupId,
+      });
+    }
+
+    nextMetaEntries.push({
+      sessionGroupId,
+      chromeGroupId,
+      windowId,
+      title,
+      color,
+    });
+  }
+
+  const activeManagedIds = new Set(nextMetaEntries.map(entry => entry.sessionGroupId));
+  groups = groups.filter(group => !managedIds.has(group.id) || activeManagedIds.has(group.id));
+  assignments = Object.fromEntries(
+    Object.entries(assignments).filter(([, groupId]) => !managedIds.has(groupId) || activeManagedIds.has(groupId))
+  );
+
+  return {
+    state: normalizeSessionGroups({ groups, assignments }),
+    importedMeta: fallbackNormalizeChromeImportedGroupMeta({ entries: nextMetaEntries }),
+    mappings,
+  };
+}
+
+const runtimeChromeImportApi = globalThis.TabOutChromeTabGroupImport || {
+  EMPTY_META: { entries: [] },
+  normalizeChromeImportedGroupMeta: fallbackNormalizeChromeImportedGroupMeta,
+  reconcileChromeTabGroupImports: fallbackReconcileChromeTabGroupImports,
+};
+
+const {
+  EMPTY_META: runtimeEmptyChromeImportedMeta,
+  normalizeChromeImportedGroupMeta,
+  reconcileChromeTabGroupImports,
+} = runtimeChromeImportApi;
 
 const {
   reorderSubsetByIds,
@@ -76,6 +228,7 @@ const {
 let openTabs = [];
 let sessionGroupsState = normalizeSessionGroups ? normalizeSessionGroups() : { groups: [], assignments: {} };
 const SESSION_GROUPS_KEY = 'sessionGroups';
+const IMPORTED_CHROME_GROUPS_KEY = 'importedChromeSessionGroups';
 let groupOrderState = normalizeGroupOrderState ? normalizeGroupOrderState() : { sessionOrder: [], pinnedOrder: [], pinEnabled: false };
 const GROUP_ORDER_KEY = 'groupOrder';
 let groupTabOrderState = {};
@@ -94,6 +247,13 @@ let draggedPageChipEl = null;
 let pageChipDragState = null;
 let pageChipPlaceholderEl = null;
 let chromeTabGroupsEnabled = false;
+let importedChromeGroupMeta = normalizeChromeImportedGroupMeta
+  ? normalizeChromeImportedGroupMeta(runtimeEmptyChromeImportedMeta)
+  : { entries: [] };
+let chromeTabGroupsImportTimer = null;
+let chromeTabGroupsUnsubscribe = null;
+let chromeTabGroupsImportInFlight = false;
+const CHROME_TAB_GROUPS_DEBUG_KEY = 'chromeTabGroupsDebug';
 
 function reorderVisibleItemsByIds(items, orderIds, includeItem) {
   if (reorderSubsetByIds) {
@@ -248,6 +408,165 @@ async function saveSessionGroups(nextState) {
   return sessionGroupsState;
 }
 
+async function loadImportedChromeGroupMeta() {
+  if (typeof normalizeChromeImportedGroupMeta !== 'function') {
+    importedChromeGroupMeta = { entries: [] };
+    return importedChromeGroupMeta;
+  }
+  const stored = await chrome.storage.local.get(IMPORTED_CHROME_GROUPS_KEY);
+  importedChromeGroupMeta = normalizeChromeImportedGroupMeta(stored[IMPORTED_CHROME_GROUPS_KEY]);
+  return importedChromeGroupMeta;
+}
+
+async function saveImportedChromeGroupMeta(nextMeta) {
+  if (typeof normalizeChromeImportedGroupMeta !== 'function') {
+    importedChromeGroupMeta = { entries: [] };
+    return importedChromeGroupMeta;
+  }
+  importedChromeGroupMeta = normalizeChromeImportedGroupMeta(nextMeta);
+  await chrome.storage.local.set({ [IMPORTED_CHROME_GROUPS_KEY]: importedChromeGroupMeta });
+  return importedChromeGroupMeta;
+}
+
+async function saveChromeTabGroupsDebug(snapshot) {
+  await chrome.storage.local.set({
+    [CHROME_TAB_GROUPS_DEBUG_KEY]: {
+      ...snapshot,
+      updatedAt: new Date().toISOString(),
+    },
+  });
+}
+
+function ensureChromeTabGroupsSubscription() {
+  if (!chromeTabGroupsEnabled || typeof subscribeToChromeTabGroupChanges !== 'function') {
+    if (chromeTabGroupsImportTimer) {
+      clearTimeout(chromeTabGroupsImportTimer);
+      chromeTabGroupsImportTimer = null;
+    }
+    if (chromeTabGroupsUnsubscribe) {
+      chromeTabGroupsUnsubscribe();
+      chromeTabGroupsUnsubscribe = null;
+    }
+    return;
+  }
+
+  if (chromeTabGroupsUnsubscribe) return;
+  chromeTabGroupsUnsubscribe = subscribeToChromeTabGroupChanges(() => {
+    scheduleChromeTabGroupsImport();
+  });
+}
+
+async function importChromeNativeGroupsIntoSessionGroups() {
+  if (!chromeTabGroupsEnabled ||
+      typeof reconcileChromeTabGroupImports !== 'function' ||
+      typeof queryExistingChromeGroups !== 'function') {
+    await saveChromeTabGroupsDebug({
+      stage: 'import-skipped',
+      enabled: chromeTabGroupsEnabled,
+      hasReconcile: typeof reconcileChromeTabGroupImports === 'function',
+      hasQuery: typeof queryExistingChromeGroups === 'function',
+    });
+    return 0;
+  }
+
+  const chromeGroups = await queryExistingChromeGroups();
+  const nativeGroups = [];
+
+  for (const chromeGroup of chromeGroups) {
+    const groupedTabs = await chrome.tabs.query({ groupId: chromeGroup.id }).catch(() => []);
+    const tabIds = groupedTabs.map(tab => tab.id).filter(tabId => tabId != null);
+    if (!tabIds.length) continue;
+    nativeGroups.push({
+      chromeGroupId: chromeGroup.id,
+      windowId: chromeGroup.windowId != null ? chromeGroup.windowId : (groupedTabs[0]?.windowId ?? 0),
+      title: chromeGroup.title || 'Group',
+      color: chromeGroup.color || 'grey',
+      tabIds,
+    });
+  }
+
+  const result = reconcileChromeTabGroupImports({
+    currentState: sessionGroupsState,
+    importedMeta: importedChromeGroupMeta,
+    nativeGroups,
+  });
+
+  await saveSessionGroups(result.state);
+  await saveImportedChromeGroupMeta(result.importedMeta);
+  if (typeof populateChromeGroupMap === 'function') {
+    await populateChromeGroupMap(result.mappings);
+  }
+  await saveChromeTabGroupsDebug({
+    stage: 'import-finished',
+    chromeGroupCount: chromeGroups.length,
+    importedNativeGroupCount: nativeGroups.length,
+    sessionGroupCount: result.state.groups.length,
+    assignmentCount: Object.keys(result.state.assignments).length,
+    importedMetaCount: result.importedMeta.entries.length,
+    chromeGroupTitles: chromeGroups.map(group => group?.title || '(untitled)'),
+    nativeGroups,
+  });
+  return nativeGroups.length;
+}
+
+function scheduleChromeTabGroupsImport() {
+  if (!chromeTabGroupsEnabled) return;
+  if (chromeTabGroupsImportTimer) clearTimeout(chromeTabGroupsImportTimer);
+  chromeTabGroupsImportTimer = setTimeout(async () => {
+    chromeTabGroupsImportTimer = null;
+    if (chromeTabGroupsImportInFlight) {
+      scheduleChromeTabGroupsImport();
+      return;
+    }
+
+    chromeTabGroupsImportInFlight = true;
+    try {
+      await fetchOpenTabs();
+      const realTabs = getRealTabs();
+      await loadSessionGroups(realTabs.map(tab => tab.id));
+      await loadImportedChromeGroupMeta();
+      const importedCount = await importChromeNativeGroupsIntoSessionGroups();
+      if (typeof setImportMode === 'function') setImportMode(importedCount > 0);
+      await renderDashboard();
+      if (typeof setImportMode === 'function') setImportMode(false);
+    } finally {
+      chromeTabGroupsImportInFlight = false;
+    }
+  }, 120);
+}
+
+async function applyChromeTabGroupsToggle(nextEnabled) {
+  const enable = Boolean(nextEnabled);
+  await saveChromeTabGroupsSetting(enable);
+  chromeTabGroupsEnabled = enable;
+
+  await fetchOpenTabs();
+  const realTabs = getRealTabs();
+  await loadSessionGroups(realTabs.map(tab => tab.id));
+  await loadImportedChromeGroupMeta();
+
+  let importedCount = 0;
+  if (enable) {
+    importedCount = await importChromeNativeGroupsIntoSessionGroups();
+  } else if (typeof reconcileChromeTabGroupImports === 'function') {
+    const cleared = reconcileChromeTabGroupImports({
+      currentState: sessionGroupsState,
+      importedMeta: importedChromeGroupMeta,
+      nativeGroups: [],
+    });
+    await saveSessionGroups(cleared.state);
+    await saveImportedChromeGroupMeta(cleared.importedMeta);
+  }
+
+  ensureChromeTabGroupsSubscription();
+  if (typeof setImportMode === 'function') setImportMode(importedCount > 0);
+  await renderDashboard();
+  if (typeof setImportMode === 'function') setImportMode(false);
+  showToast(enable
+    ? (runtimeT ? runtimeT('toastChromeTabGroupsOn') : 'Chrome tab groups on')
+    : (runtimeT ? runtimeT('toastChromeTabGroupsOff') : 'Chrome tab groups off'));
+}
+
 async function loadGroupOrder() {
   const stored = await chrome.storage.local.get(GROUP_ORDER_KEY);
   groupOrderState = normalizeGroupOrderState(stored[GROUP_ORDER_KEY]);
@@ -276,7 +595,9 @@ function updateGroupNavButtonIcon(groupKey) {
 
   if (img && iconData.src) {
     img.src = iconData.src;
-    img.setAttribute('onerror', `handleIconError(this, '${iconData.fallbackSrc}')`);
+    if (typeof runtimeSetImageFallbackAttributes === 'function') {
+      runtimeSetImageFallbackAttributes(img, iconData.fallbackSrc);
+    }
     img.style.display = '';
     if (fallback) {
       fallback.textContent = iconData.fallbackLabel;
@@ -793,6 +1114,9 @@ async function focusTab(url) {
   const match = matches.find(t => t.windowId !== currentWindow.id) || matches[0];
   await chrome.tabs.update(match.id, { active: true });
   await chrome.windows.update(match.windowId, { focused: true });
+  if (typeof syncChromeTabGroupExpansionForTab === 'function') {
+    await syncChromeTabGroupExpansionForTab(match);
+  }
   return true;
 }
 
@@ -942,8 +1266,9 @@ function buildOverflowChips(hiddenTabs, urlCounts = {}) {
     const faviconUrl = iconData.sources[0] || '';
     const fallbackUrl = iconData.sources[1] || '';
     const fallbackLabel = runtimeGetFallbackLabel(label, iconData.hostname);
+    const safeFallbackUrl = runtimeEscapeHtmlAttribute ? runtimeEscapeHtmlAttribute(fallbackUrl) : fallbackUrl.replace(/"/g, '&quot;');
     return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" aria-label="${safeTitle}">
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="handleIconError(this, '${fallbackUrl}')">` : ''}
+      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" data-fallback-src="${safeFallbackUrl}">` : ''}
       <span class="chip-favicon chip-favicon-fallback"${faviconUrl ? ' style="display:none"' : ''}>${fallbackLabel}</span>
       <span class="chip-text">${label}</span>${dupeTag}
       <div class="chip-actions">
@@ -1039,11 +1364,12 @@ function renderDomainCard(group) {
     const faviconUrl = iconData.sources[0] || '';
     const fallbackUrl = iconData.sources[1] || '';
     const fallbackLabel = runtimeGetFallbackLabel(label, iconData.hostname);
+    const safeFallbackUrl = runtimeEscapeHtmlAttribute ? runtimeEscapeHtmlAttribute(fallbackUrl) : fallbackUrl.replace(/"/g, '&quot;');
     return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" data-chip-sort-id="${safeSortId}" data-chip-group-id="${safeGroupId}" aria-label="${safeTitle}">
       <button class="drawer-reorder-handle chip-reorder-handle" type="button" data-chip-drag-handle="tab" aria-label="${runtimeT ? runtimeT('dragReorderTab') : 'Drag to reorder tab'}">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M8 6h.01M8 12h.01M8 18h.01M16 6h.01M16 12h.01M16 18h.01" /></svg>
       </button>
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="handleIconError(this, '${fallbackUrl}')">` : ''}
+      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" data-fallback-src="${safeFallbackUrl}">` : ''}
       <span class="chip-favicon chip-favicon-fallback"${faviconUrl ? ' style="display:none"' : ''}>${fallbackLabel}</span>
       <span class="chip-text">${label}</span>${dupeTag}
       <div class="chip-actions">
@@ -1119,7 +1445,7 @@ function renderGroupNav(group) {
       draggable="false"
     >
       ${iconData.src
-        ? `<img class="group-nav-icon" src="${iconData.src}" alt="" draggable="false" onerror="handleIconError(this, '${iconData.fallbackSrc}')">`
+        ? `<img class="group-nav-icon" src="${iconData.src}" alt="" draggable="false" data-fallback-src="${runtimeEscapeHtmlAttribute(iconData.fallbackSrc)}">`
         : ''}
       <span class="group-nav-fallback"${iconData.src ? ' style="display:none"' : ''}>${iconData.fallbackLabel}</span>
     </button>`;
@@ -1419,27 +1745,6 @@ async function renderDashboard() {
   }
 }
 
-function handleIconError(imgEl, fallbackUrl) {
-  if (!imgEl) return;
-
-  if (fallbackUrl && imgEl.dataset.fallbackApplied !== 'true') {
-    imgEl.dataset.fallbackApplied = 'true';
-    imgEl.src = fallbackUrl;
-    return;
-  }
-
-  imgEl.style.display = 'none';
-  const sibling = imgEl.nextElementSibling;
-  if (sibling && (
-    sibling.classList.contains('group-nav-fallback') ||
-    sibling.classList.contains('chip-favicon-fallback') ||
-    sibling.classList.contains('inline-favicon-fallback') ||
-    sibling.classList.contains('quick-shortcut-fallback')
-  )) {
-    sibling.style.display = sibling.classList.contains('inline-favicon-fallback') ? 'inline-flex' : 'flex';
-  }
-}
-
 function updateBackToTopVisibility() {
   const button = document.getElementById('backToTopBtn');
   if (!button) return;
@@ -1619,65 +1924,6 @@ document.addEventListener('click', async (e) => {
   }
 
   if (action === 'toggle-chrome-tab-groups') {
-    e.stopPropagation();
-    const nextEnabled = !isChromeTabGroupsEnabled();
-
-    if (nextEnabled && typeof queryExistingChromeGroups === 'function' && typeof populateChromeGroupMap === 'function') {
-      const existingGroups = await queryExistingChromeGroups();
-      if (existingGroups.length > 0) {
-        let state = normalizeSessionGroups(sessionGroupsState);
-        const mappings = [];
-        for (const chromeGroup of existingGroups) {
-          const tabs = await chrome.tabs.query({ groupId: chromeGroup.id }).catch(() => []);
-          const tabIds = tabs.map(t => t.id).filter(Boolean);
-          if (tabIds.length === 0) continue;
-          const name = chromeGroup.title || 'Group';
-          let group;
-          try {
-            const result = addSessionGroup(state, name);
-            state = result.state;
-            group = result.group;
-          } catch {
-            // Name collision — generate a unique suffix so distinct
-            // Chrome groups are never merged into one session group.
-            let suffix = 2;
-            let uniqueName = `${name} ${suffix}`;
-            while (state.groups.some(g => g.name.toLowerCase() === uniqueName.toLowerCase())) {
-              suffix++;
-              uniqueName = `${name} ${suffix}`;
-            }
-            const result = addSessionGroup(state, uniqueName);
-            state = result.state;
-            group = result.group;
-          }
-          if (group) {
-            for (const tabId of tabIds) {
-              state = assignTabToSessionGroup(state, tabId, group.id);
-            }
-            const uniqueWindows = new Set(tabs.map(t => t.windowId));
-            for (const windowId of uniqueWindows) {
-              mappings.push({
-                virtualGroupKey: `__session_group__:${group.id}`,
-                windowId,
-                chromeGroupId: chromeGroup.id,
-              });
-            }
-          }
-        }
-        if (mappings.length > 0) {
-          await saveSessionGroups(state);
-          await populateChromeGroupMap(mappings);
-          if (typeof setImportMode === 'function') setImportMode(true);
-        }
-      }
-    }
-
-    await saveChromeTabGroupsSetting(nextEnabled);
-    chromeTabGroupsEnabled = nextEnabled;
-    if (typeof setThemeMenuOpen === 'function') setThemeMenuOpen(false);
-    await renderDashboard();
-    if (typeof setImportMode === 'function') setImportMode(false);
-    showToast(nextEnabled ? (runtimeT ? runtimeT('toastChromeTabGroupsOn') : 'Chrome tab groups on') : (runtimeT ? runtimeT('toastChromeTabGroupsOff') : 'Chrome tab groups off'));
     return;
   }
 
@@ -2384,6 +2630,12 @@ document.addEventListener('input', async (e) => {
 });
 
 document.addEventListener('change', async (e) => {
+  if (e.target.matches('input[data-action="toggle-chrome-tab-groups"]')) {
+    if (typeof setThemeMenuOpen === 'function') setThemeMenuOpen(false);
+    await applyChromeTabGroupsToggle(e.target.checked);
+    return;
+  }
+
   if (e.target.id !== 'themeBackgroundInput') return;
 
   const file = e.target.files?.[0];
@@ -2421,7 +2673,17 @@ async function initializeDashboardRuntime() {
   if (typeof loadChromeTabGroupsSetting === 'function') {
     chromeTabGroupsEnabled = await loadChromeTabGroupsSetting();
   }
+  await loadImportedChromeGroupMeta();
+  if (chromeTabGroupsEnabled) {
+    await fetchOpenTabs();
+    const realTabs = getRealTabs();
+    await loadSessionGroups(realTabs.map(tab => tab.id));
+    const importedCount = await importChromeNativeGroupsIntoSessionGroups();
+    if (typeof setImportMode === 'function') setImportMode(importedCount > 0);
+  }
+  ensureChromeTabGroupsSubscription();
   await renderDashboard();
+  if (typeof setImportMode === 'function') setImportMode(false);
   updateBackToTopVisibility();
 }
 

--- a/extension/dashboard-runtime.js
+++ b/extension/dashboard-runtime.js
@@ -1638,7 +1638,17 @@ document.addEventListener('click', async (e) => {
             state = result.state;
             group = result.group;
           } catch {
-            group = state.groups.find(g => g.name === name);
+            // Name collision — generate a unique suffix so distinct
+            // Chrome groups are never merged into one session group.
+            let suffix = 2;
+            let uniqueName = `${name} ${suffix}`;
+            while (state.groups.some(g => g.name.toLowerCase() === uniqueName.toLowerCase())) {
+              suffix++;
+              uniqueName = `${name} ${suffix}`;
+            }
+            const result = addSessionGroup(state, uniqueName);
+            state = result.state;
+            group = result.group;
           }
           if (group) {
             for (const tabId of tabIds) {
@@ -1656,7 +1666,7 @@ document.addEventListener('click', async (e) => {
         }
         if (mappings.length > 0) {
           await saveSessionGroups(state);
-          populateChromeGroupMap(mappings);
+          await populateChromeGroupMap(mappings);
           if (typeof setImportMode === 'function') setImportMode(true);
         }
       }
@@ -1664,6 +1674,7 @@ document.addEventListener('click', async (e) => {
 
     await saveChromeTabGroupsSetting(nextEnabled);
     chromeTabGroupsEnabled = nextEnabled;
+    if (typeof setThemeMenuOpen === 'function') setThemeMenuOpen(false);
     await renderDashboard();
     if (typeof setImportMode === 'function') setImportMode(false);
     showToast(nextEnabled ? (runtimeT ? runtimeT('toastChromeTabGroupsOn') : 'Chrome tab groups on') : (runtimeT ? runtimeT('toastChromeTabGroupsOff') : 'Chrome tab groups off'));

--- a/extension/drawer-manager.js
+++ b/extension/drawer-manager.js
@@ -450,6 +450,7 @@ function renderDeferredItem(item) {
   const faviconUrl = iconData.sources[0] || '';
   const fallbackUrl = iconData.sources[1] || '';
   const fallbackLabel = drawerGetFallbackLabel(item.title || item.url, iconData.hostname);
+  const safeFallbackUrl = fallbackUrl.replace(/"/g, '&quot;');
   const ago = timeAgo(item.savedAt);
   const dragHandle = !savedSearchQuery.trim()
     ? `<button class="drawer-reorder-handle" type="button" data-drag-handle="saved" aria-label="Drag to reorder saved page">
@@ -462,7 +463,7 @@ function renderDeferredItem(item) {
       <input type="checkbox" class="deferred-checkbox" data-action="check-deferred" data-deferred-id="${item.id}">
       <div class="deferred-info">
         <a href="${item.url}" target="_blank" rel="noopener" class="deferred-title" title="${(item.title || '').replace(/"/g, '&quot;')}">
-          ${faviconUrl ? `<img src="${faviconUrl}" alt="" style="width:14px;height:14px;vertical-align:-2px;margin-right:4px" onerror="handleIconError(this, '${fallbackUrl}')">` : ''}
+          ${faviconUrl ? `<img src="${faviconUrl}" alt="" style="width:14px;height:14px;vertical-align:-2px;margin-right:4px" data-fallback-src="${safeFallbackUrl}">` : ''}
           <span class="inline-favicon-fallback"${faviconUrl ? ' style="display:none"' : ''}>${fallbackLabel}</span>${item.title || item.url}
         </a>
         <div class="deferred-meta">

--- a/extension/i18n.js
+++ b/extension/i18n.js
@@ -122,6 +122,9 @@
       languageAuto: 'Auto',
       languageEnglish: 'English',
       languageChinese: '中文',
+      chromeTabGroupsLabel: 'Chrome tab groups',
+      toastChromeTabGroupsOn: 'Chrome tab groups on',
+      toastChromeTabGroupsOff: 'Chrome tab groups off',
     },
     'zh-CN': {
       emptyTitle: '标签页清零了。',
@@ -219,6 +222,9 @@
       languageAuto: '自动',
       languageEnglish: 'English',
       languageChinese: '中文',
+      chromeTabGroupsLabel: 'Chrome 标签组',
+      toastChromeTabGroupsOn: '已启用 同步Chrome标签组',
+      toastChromeTabGroupsOff: '已禁用 同步Chrome标签组',
     },
   };
 
@@ -287,6 +293,8 @@
     'Add quick tab': '添加快捷链接',
     'Edit quick tab': '编辑快捷链接',
     'Remove quick tab': '删除快捷链接',
+    'Sync Chrome tab groups': '同步Chrome标签组',
+    'Homepages': '主页',
   };
 
   function i18nFormat(template, vars = {}) {

--- a/extension/index.html
+++ b/extension/index.html
@@ -316,6 +316,7 @@
 <script src="ui-helpers.js"></script>
 <script src="theme-controls.js"></script>
 <script src="drawer-manager.js"></script>
+<script src="chrome-tab-groups-sync.js"></script>
 <script src="dashboard-runtime.js"></script>
 
 <!-- Main dashboard logic — loads last so the DOM is ready -->

--- a/extension/index.html
+++ b/extension/index.html
@@ -301,9 +301,9 @@
   </svg>
 </button>
 
-<!-- Personal config (gitignored) — defines LOCAL_LANDING_PAGE_PATTERNS etc. -->
-<!-- If the file doesn't exist, that's fine — app.js uses sensible defaults. -->
-<script src="config.local.js"></script>
+<!-- Checked-in defaults + optional local overrides -->
+<script src="config.js"></script>
+<script src="config-loader.js"></script>
 
 <!-- Shared icon helpers — real favicons first, then graceful fallbacks -->
 <script src="icon-utils.js"></script>
@@ -317,6 +317,7 @@
 <script src="ui-helpers.js"></script>
 <script src="theme-controls.js"></script>
 <script src="drawer-manager.js"></script>
+<script src="chrome-tab-groups-import.js"></script>
 <script src="chrome-tab-groups-sync.js"></script>
 <script src="dashboard-runtime.js"></script>
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tab Harbor",
   "version": "1.0.0",
   "description": "A new tab dashboard for organizing open tabs, quick links, todos, and saved reads in one calm workspace.",
-  "permissions": ["tabs", "storage", "search", "clipboardRead"],
+  "permissions": ["tabs", "storage", "search", "clipboardRead", "tabGroups"],
   "chrome_url_overrides": { "newtab": "index.html" },
   "background": { "service_worker": "background.js" },
   "action": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,8 @@
   "name": "Tab Harbor",
   "version": "1.0.0",
   "description": "A new tab dashboard for organizing open tabs, quick links, todos, and saved reads in one calm workspace.",
-  "permissions": ["tabs", "storage", "search", "clipboardRead", "tabGroups"],
+  "permissions": ["tabs", "storage", "search", "clipboardRead"],
+  "optional_permissions": ["tabGroups"],
   "chrome_url_overrides": { "newtab": "index.html" },
   "background": { "service_worker": "background.js" },
   "action": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,8 +3,7 @@
   "name": "Tab Harbor",
   "version": "1.0.0",
   "description": "A new tab dashboard for organizing open tabs, quick links, todos, and saved reads in one calm workspace.",
-  "permissions": ["tabs", "storage", "search", "clipboardRead"],
-  "optional_permissions": ["tabGroups"],
+  "permissions": ["tabs", "storage", "search", "clipboardRead", "tabGroups"],
   "chrome_url_overrides": { "newtab": "index.html" },
   "background": { "service_worker": "background.js" },
   "action": {

--- a/extension/style.css
+++ b/extension/style.css
@@ -745,6 +745,59 @@ body.quick-shortcut-list-dragging .quick-shortcut-open {
   color: var(--ink);
 }
 
+/* ---- Chrome tab groups toggle ---- */
+.theme-menu-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.theme-menu-toggle-label input[type="checkbox"] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+.theme-menu-toggle-slider {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  flex-shrink: 0;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--warm-gray) 60%, var(--muted) 40%);
+  transition: background 0.2s ease;
+}
+
+.theme-menu-toggle-slider::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: var(--card-bg);
+  transition: transform 0.2s cubic-bezier(0.22, 1, 0.36, 1);
+  box-shadow: 0 1px 3px color-mix(in srgb, var(--ink) 20%, transparent);
+}
+
+.theme-menu-toggle-label input[type="checkbox"]:checked + .theme-menu-toggle-slider {
+  background: var(--workspace-accent);
+}
+
+.theme-menu-toggle-label input[type="checkbox"]:checked + .theme-menu-toggle-slider::after {
+  transform: translateX(16px);
+}
+
+.theme-menu-toggle-label .theme-menu-label {
+  cursor: pointer;
+}
+
 /* ---- Tab cleanup banner ---- */
 .tab-cleanup-banner {
   background: linear-gradient(

--- a/extension/style.css
+++ b/extension/style.css
@@ -757,10 +757,20 @@ body.quick-shortcut-list-dragging .quick-shortcut-open {
 
 .theme-menu-toggle-label input[type="checkbox"] {
   position: absolute;
-  opacity: 0;
-  width: 0;
-  height: 0;
-  pointer-events: none;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.theme-menu-toggle-label input[type="checkbox"]:focus-visible + .theme-menu-toggle-slider {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+  box-shadow: var(--focus-ring-shadow);
 }
 
 .theme-menu-toggle-slider {

--- a/extension/theme-controls.js
+++ b/extension/theme-controls.js
@@ -852,6 +852,8 @@ function renderQuickShortcutCard(shortcut) {
   const safeId = themeEscapeHtmlAttribute ? themeEscapeHtmlAttribute(shortcut.id) : shortcut.id.replace(/"/g, '&quot;');
   const safeUrl = themeEscapeHtmlAttribute ? themeEscapeHtmlAttribute(shortcut.url) : shortcut.url.replace(/"/g, '&quot;');
   const customIcon = normalizeShortcutIcon(shortcut.icon);
+  const iconErrorFallback = (customIcon.kind === 'image' || customIcon.kind === 'svg') ? (faviconUrl || fallbackUrl) : fallbackUrl;
+  const safeIconErrorFallback = themeEscapeHtmlAttribute ? themeEscapeHtmlAttribute(iconErrorFallback) : iconErrorFallback.replace(/"/g, '&quot;');
   const primaryIconUrl = customIcon.kind === 'image'
     ? customIcon.value
     : customIcon.kind === 'svg'
@@ -859,14 +861,13 @@ function renderQuickShortcutCard(shortcut) {
     : customIcon.kind === 'glyph'
       ? ''
       : faviconUrl;
-  const iconErrorFallback = (customIcon.kind === 'image' || customIcon.kind === 'svg') ? (faviconUrl || fallbackUrl) : fallbackUrl;
   const glyphIcon = customIcon.kind === 'glyph' ? customIcon.value : '';
 
   return `
     <div class="quick-shortcut-card" data-shortcut-id="${safeId}">
       <button class="quick-shortcut-open" type="button" data-action="open-quick-shortcut" data-shortcut-url="${safeUrl}" aria-label="${label}" draggable="false">
         <span class="quick-shortcut-icon-wrap">
-          ${primaryIconUrl ? `<img class="quick-shortcut-icon${customIcon.kind === 'image' ? ' quick-shortcut-icon-custom' : ''}" src="${primaryIconUrl}" alt="" draggable="false" onerror="handleIconError(this, '${iconErrorFallback}')">` : ''}
+          ${primaryIconUrl ? `<img class="quick-shortcut-icon${customIcon.kind === 'image' ? ' quick-shortcut-icon-custom' : ''}" src="${primaryIconUrl}" alt="" draggable="false" data-fallback-src="${safeIconErrorFallback}">` : ''}
           ${glyphIcon ? `<span class="quick-shortcut-custom-glyph" aria-hidden="true">${glyphIcon}</span>` : ''}
           <span class="quick-shortcut-fallback"${primaryIconUrl || glyphIcon ? ' style="display:none"' : ''}>${fallbackLabel}</span>
         </span>

--- a/extension/ui-helpers.js
+++ b/extension/ui-helpers.js
@@ -135,6 +135,54 @@ function showToast(message) {
   setTimeout(() => toast.classList.remove('visible'), 2500);
 }
 
+function setImageFallbackAttributes(imgEl, fallbackUrl = '') {
+  if (!imgEl) return;
+  if (fallbackUrl) {
+    imgEl.dataset.fallbackSrc = String(fallbackUrl);
+  } else {
+    delete imgEl.dataset.fallbackSrc;
+  }
+  delete imgEl.dataset.fallbackApplied;
+}
+
+function revealImageFallback(imgEl) {
+  if (!imgEl) return;
+  imgEl.style.display = 'none';
+  const sibling = imgEl.nextElementSibling;
+  if (!sibling) return;
+  if (
+    sibling.classList.contains('group-nav-fallback') ||
+    sibling.classList.contains('chip-favicon-fallback') ||
+    sibling.classList.contains('inline-favicon-fallback') ||
+    sibling.classList.contains('quick-shortcut-fallback')
+  ) {
+    sibling.style.display = sibling.classList.contains('inline-favicon-fallback') ? 'inline-flex' : 'flex';
+  }
+}
+
+function handleImageFallbackError(imgEl) {
+  if (!imgEl) return;
+  const fallbackUrl = String(imgEl.dataset.fallbackSrc || '').trim();
+
+  if (fallbackUrl && imgEl.dataset.fallbackApplied !== 'true') {
+    imgEl.dataset.fallbackApplied = 'true';
+    imgEl.src = fallbackUrl;
+    return;
+  }
+
+  revealImageFallback(imgEl);
+}
+
+if (!globalThis.__tabHarborImageFallbackBound) {
+  document.addEventListener('error', event => {
+    const target = event.target;
+    if (!(target instanceof HTMLImageElement)) return;
+    if (!('fallbackSrc' in target.dataset)) return;
+    handleImageFallbackError(target);
+  }, true);
+  globalThis.__tabHarborImageFallbackBound = true;
+}
+
 function renderMissionsEmptyState() {
   return `
     <div class="missions-empty-state">

--- a/extension/ui-regression.test.js
+++ b/extension/ui-regression.test.js
@@ -10,6 +10,8 @@ const runtimeJs = fs.readFileSync(path.join(__dirname, 'dashboard-runtime.js'), 
 const themeJs = fs.readFileSync(path.join(__dirname, 'theme-controls.js'), 'utf8');
 const drawerJs = fs.readFileSync(path.join(__dirname, 'drawer-manager.js'), 'utf8');
 const helperJs = fs.readFileSync(path.join(__dirname, 'ui-helpers.js'), 'utf8');
+const configJs = fs.readFileSync(path.join(__dirname, 'config.js'), 'utf8');
+const configLoaderJs = fs.readFileSync(path.join(__dirname, 'config-loader.js'), 'utf8');
 const appJs = [appEntryJs, runtimeJs, themeJs, drawerJs, helperJs].join('\n');
 
 test('move menu keeps hidden state until explicitly opened', () => {
@@ -68,6 +70,14 @@ test('group nav icons disable native image dragging', () => {
   assert.match(css, /\.group-nav-button,\s*\.group-nav-button \*\s*\{[\s\S]*-webkit-user-drag:\s*none;/);
 });
 
+test('icon fallback handling avoids inline event handlers', () => {
+  assert.doesNotMatch(appJs, /onerror=/);
+  assert.match(appJs, /data-fallback-src=/);
+  assert.match(helperJs, /document\.addEventListener\('error', event =>/);
+  assert.match(helperJs, /handleImageFallbackError/);
+  assert.match(helperJs, /setImageFallbackAttributes/);
+});
+
 test('index includes a back-to-top floating button', () => {
   assert.match(html, /id="backToTopBtn"/);
 });
@@ -86,6 +96,19 @@ test('index includes deferred drawer trigger and overlay', () => {
   assert.doesNotMatch(html, /deferredTriggerIconPath/);
   assert.doesNotMatch(html, /id="deferredTriggerCount"/);
   assert.doesNotMatch(html, /deferred-trigger-label/);
+});
+
+test('optional local config is loaded safely before app mount', () => {
+  assert.match(html, /<script src="config\.js"><\/script>/);
+  assert.match(html, /<script src="config-loader\.js"><\/script>/);
+  assert.doesNotMatch(html, /<script src="config\.local\.js"><\/script>/);
+  assert.match(configJs, /LOCAL_LANDING_PAGE_PATTERNS/);
+  assert.match(configJs, /LOCAL_CUSTOM_GROUPS/);
+  assert.match(configLoaderJs, /TabHarborConfigReady/);
+  assert.match(configLoaderJs, /script\.src = 'config\.local\.js'/);
+  assert.match(configLoaderJs, /script\.onerror = \(\) => resolve\(\)/);
+  assert.match(appEntryJs, /TabHarborConfigReady/);
+  assert.match(appEntryJs, /await appConfigReady/);
 });
 
 test('manifest keeps only permissions required by the shipped runtime', () => {


### PR DESCRIPTION
Chrome 原生标签组双向同步

> #7 增加对Chrome标签组支持，Edge工作区没有API，暂未实现

## Change

1. **国际化 (i18n)** — 补全缺失的i18n
2. **Chrome 原生标签组同步** — 可选的双向同步：插件虚拟分组 ↔ Chrome `tabGroups` API

## Chrome 原生标签组同步

- 主题菜单新增开关：`Chrome 标签组` 
- **默认关闭** — 不创建任何 Chrome 标签组，原有行为完全不变
- **打开开关，无现有 Chrome 标签组** — 将插件的分组（域名组、会话组）同步到 Chrome，创建带标题和颜色的原生标签组
- **打开开关，已有 Chrome 标签组** — 将 Chrome 标签组导入为插件的会话组，保留 Chrome 组原有的标题和颜色。导入阶段不为此前未分组的标签创建新的 Chrome 组
- **关闭开关** — 取消所有此前跟踪的 Chrome 标签分组
- **窗口隔离**：不同窗口的标签创建独立的 Chrome 标签组

- **最新更改**：新增了标签组数据持久化到localstorage，修复ai review发现的问题

## 预览

<img width="341" height="465" alt="截屏2026-04-27 23 07 41" src="https://github.com/user-attachments/assets/18881e60-8191-49dc-bc6e-44836af9171e" />

Chrome标签页分组双向同步 #7 

<img width="268" height="468" alt="截屏2026-04-27 23 07 49" src="https://github.com/user-attachments/assets/65a7d085-082e-4bf9-8f8e-8172f801e819" />

