### PR TITLE
fix: 隔离新标签页窗口状态

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,5 @@
+When performing a code review, respond in Simplified Chinese.
+
 ## Design Context
 
 ### Product Overview

--- a/extension/chrome-tab-groups-sync.js
+++ b/extension/chrome-tab-groups-sync.js
@@ -286,18 +286,32 @@
 
     const validGroupIds = new Set(currentGroups.map(g => g.id));
 
-    // Remove orphaned Chrome groups (tracked but no longer needed)
-    const neededKeys = new Set(Object.keys(desired));
+    // Remove orphaned Chrome groups only for windows represented in this sync.
+    // Other windows may be managed by their own Tab Harbor new-tab page.
+    const desiredWindowIds = new Set(
+      Object.values(desired)
+        .flatMap(windowMap => Object.keys(windowMap))
+        .map(windowId => Number(windowId))
+        .filter(Number.isFinite)
+    );
     for (const [groupKey, windowMap] of Object.entries(chromeGroupMap)) {
-      if (!neededKeys.has(groupKey)) {
-        for (const chromeGroupId of Object.values(windowMap)) {
-          if (validGroupIds.has(chromeGroupId)) {
-            try {
-              const tabs = await chrome.tabs.query({ groupId: chromeGroupId });
-              await ungroupTabs(tabs.map(t => t.id).filter(Boolean));
-            } catch {}
-          }
+      for (const [windowIdStr, chromeGroupId] of Object.entries(windowMap)) {
+        const windowId = Number(windowIdStr);
+        if (!validGroupIds.has(chromeGroupId)) {
+          delete windowMap[windowIdStr];
+          continue;
         }
+
+        if (desiredWindowIds.has(windowId) && !desired[groupKey]?.[windowId]) {
+          try {
+            const tabs = await chrome.tabs.query({ groupId: chromeGroupId });
+            await ungroupTabs(tabs.map(t => t.id).filter(Boolean));
+          } catch {}
+          delete windowMap[windowIdStr];
+        }
+      }
+
+      if (Object.keys(windowMap).length === 0) {
         delete chromeGroupMap[groupKey];
       }
     }

--- a/extension/chrome-tab-groups-sync.test.js
+++ b/extension/chrome-tab-groups-sync.test.js
@@ -403,6 +403,41 @@ test('syncChromeTabGroups reuses chromeGroupMap populated by populateChromeGroup
   assert.deepEqual(lastGroupCall.tabIds, [10]);
 });
 
+test('syncChromeTabGroups only removes obsolete mappings in synced windows', async () => {
+  resetChromeGroupState();
+  const ungroupedTabIds = [];
+
+  globalThis.chrome.tabs.group = async (opts) => opts.groupId ?? 700;
+  globalThis.chrome.tabs.ungroup = async (tabIds) => {
+    ungroupedTabIds.push(...tabIds);
+  };
+  globalThis.chrome.tabGroups.update = async () => {};
+  globalThis.chrome.tabGroups.query = async () => [
+    { id: 501, title: 'GitHub', color: 'grey', windowId: 1 },
+    { id: 502, title: 'GitHub', color: 'grey', windowId: 2 },
+    { id: 503, title: 'Docs', color: 'blue', windowId: 2 },
+  ];
+  globalThis.chrome.tabs.query = async (opts) => {
+    if (opts?.groupId === 502) return [{ id: 202, windowId: 2 }];
+    if (opts?.groupId === 503) return [{ id: 203, windowId: 2 }];
+    return [];
+  };
+
+  await saveChromeTabGroupsSetting(true);
+  populateChromeGroupMap([
+    { virtualGroupKey: 'github.com', windowId: 1, chromeGroupId: 501 },
+    { virtualGroupKey: 'github.com', windowId: 2, chromeGroupId: 502 },
+    { virtualGroupKey: 'docs.example', windowId: 2, chromeGroupId: 503 },
+  ]);
+
+  await syncChromeTabGroups([
+    { domain: 'github.com', tabs: [{ id: 101, windowId: 1, url: 'https://github.com' }] },
+  ]);
+
+  assert.deepEqual(ungroupedTabIds, []);
+  assert.equal(getChromeGroupCount(), 2);
+});
+
 test('syncChromeTabGroups in import mode skips creating new groups for ungrouped tabs', async () => {
   resetChromeGroupState();
   let createCalls = 0;

--- a/extension/dashboard-runtime.js
+++ b/extension/dashboard-runtime.js
@@ -105,8 +105,9 @@ const {
    access to chrome.tabs and chrome.storage. No middleman needed.
    ---------------------------------------------------------------- */
 
-// All open tabs — populated by fetchOpenTabs()
+// Visible open tabs for this dashboard window — populated by fetchOpenTabs()
 let openTabs = [];
+let allOpenTabIds = [];
 let sessionGroupsState = normalizeSessionGroups ? normalizeSessionGroups() : { groups: [], assignments: {} };
 const MANUAL_GROUP_PREFIX = '__session_group__:';
 const PAGE_CHIP_DRAG_DEBUG = false;
@@ -155,6 +156,7 @@ let chromeTabGroupsUnsubscribe = null;
 let chromeTabGroupsImportInFlight = false;
 let suppressChromeTabGroupsImportUntil = 0;
 let currentDashboardTabId = null;
+let currentDashboardWindowId = null;
 let dashboardStartupTabChangeIgnoreUntil = 0;
 const ENTRY_ANIMATIONS_CLASS = 'entry-animations-enabled';
 let entryAnimationsTimer = null;
@@ -708,8 +710,14 @@ async function fetchOpenTabs() {
   try {
     const newtabUrl = window.location.href;
 
+    const currentWindowId = await getDashboardWindowIdForOpenTabs();
     const tabs = await chrome.tabs.query({});
-    openTabs = tabs.map(t => {
+    allOpenTabIds = tabs.map(tab => tab?.id).filter(tabId => tabId != null);
+    const visibleTabs = currentWindowId == null
+      ? tabs
+      : tabs.filter(t => t.windowId === currentWindowId);
+
+    openTabs = visibleTabs.map(t => {
       const rawUrl = t.url || '';
       const suspended = runtimeParseSuspendedTabUrl
         ? runtimeParseSuspendedTabUrl(rawUrl)
@@ -735,7 +743,20 @@ async function fetchOpenTabs() {
   } catch {
     // chrome.tabs API unavailable (shouldn't happen in an extension page)
     openTabs = [];
+    allOpenTabIds = [];
   }
+}
+
+function getOpenTabIdsForSessionPruning() {
+  return allOpenTabIds.length > 0 ? allOpenTabIds : openTabs.map(tab => tab.id);
+}
+
+async function queryTabsForDashboardWindow() {
+  const tabs = await chrome.tabs.query({});
+  const currentWindowId = await getDashboardWindowIdForOpenTabs();
+  return currentWindowId == null
+    ? tabs
+    : tabs.filter(tab => tab.windowId === currentWindowId);
 }
 
 async function loadSessionGroups(openTabIds = []) {
@@ -920,7 +941,7 @@ function scheduleChromeTabGroupsImport() {
     try {
       await fetchOpenTabs();
       const realTabs = getRealTabs();
-      await loadSessionGroups(realTabs.map(tab => tab.id));
+      await loadSessionGroups(getOpenTabIdsForSessionPruning());
       await loadImportedChromeGroupMeta();
       if (!shouldImportChromeGroupsIntoSessionState()) {
         disableChromeTabGroupsImportModeForLocalEdits();
@@ -949,7 +970,7 @@ async function applyChromeTabGroupsToggle(nextEnabled) {
 
   await fetchOpenTabs();
   const realTabs = getRealTabs();
-  await loadSessionGroups(realTabs.map(tab => tab.id));
+  await loadSessionGroups(getOpenTabIdsForSessionPruning());
   await loadImportedChromeGroupMeta();
 
   let importedCount = 0;
@@ -1072,6 +1093,23 @@ async function getCurrentWindowId() {
   return currentWindow?.id;
 }
 
+async function getDashboardWindowIdForOpenTabs() {
+  if (currentDashboardWindowId != null) return currentDashboardWindowId;
+
+  const currentTab = await resolveCurrentDashboardTab();
+  if (currentTab?.windowId != null) {
+    currentDashboardWindowId = currentTab.windowId;
+    return currentDashboardWindowId;
+  }
+
+  try {
+    currentDashboardWindowId = await getCurrentWindowId();
+  } catch {
+    currentDashboardWindowId = null;
+  }
+  return currentDashboardWindowId;
+}
+
 function getTabCanonicalUrl(tab) {
   return runtimeGetCanonicalTabUrl ? runtimeGetCanonicalTabUrl(tab?.url || '') : String(tab?.url || '');
 }
@@ -1100,7 +1138,7 @@ function getTabGroupLookup(groups = domainGroups) {
 async function refreshTabSessionModel() {
   await fetchOpenTabs();
   const realTabs = getRealTabs();
-  await loadSessionGroups(realTabs.map(tab => tab.id));
+  await loadSessionGroups(getOpenTabIdsForSessionPruning());
   await loadGroupOrder();
   await loadGroupLabelOverrides();
   await buildDomainGroups(realTabs);
@@ -1608,7 +1646,7 @@ async function removeOpenTabByIdOrUrl(tabId, tabUrl) {
     return numericTabId;
   }
 
-  const allTabs = await chrome.tabs.query({});
+  const allTabs = await queryTabsForDashboardWindow();
   const targetUrl = runtimeGetCanonicalTabUrl ? runtimeGetCanonicalTabUrl(tabUrl || '') : tabUrl;
   const match = allTabs.find(tab => {
     const canonicalUrl = getTabCanonicalUrl(tab);
@@ -2090,7 +2128,7 @@ async function moveDraggedPageChipToGroup(targetGroupKey) {
   let nextState = clearTabsFromSessionGroups(sessionGroupsState, draggedTabIds);
   const targetGroup = ensureManualDropGroup(nextState, targetGroupKey);
   nextState = reassignTabsToSessionGroup(targetGroup.nextState, draggedTabIds, targetGroup.groupId);
-  nextState = pruneSessionGroups(nextState, openTabs.map(tab => tab.id));
+  nextState = pruneSessionGroups(nextState, getOpenTabIdsForSessionPruning());
   logPageChipDragDebug('move-group-save-session', {
     groupId: targetGroup.groupId,
     groupName: targetGroup.groupName,
@@ -2125,7 +2163,7 @@ async function createSessionGroupFromDraggedPageChip() {
   let nextState = clearTabsFromSessionGroups(sessionGroupsState, draggedTabIds);
   const created = createSessionGroupFromDraggedTab(nextState, draggedTabs[0]);
   nextState = reassignTabsToSessionGroup(created.state, draggedTabIds, created.group.id);
-  nextState = pruneSessionGroups(nextState, openTabs.map(tab => tab.id));
+  nextState = pruneSessionGroups(nextState, getOpenTabIdsForSessionPruning());
   logPageChipDragDebug('create-group-save-session', {
     groupId: created.group.id,
     groupName: created.group.name,
@@ -2349,7 +2387,7 @@ async function removeTabAssignments(tabIds = []) {
     nextState = clearTabSessionGroup(nextState, tabId);
   }
 
-  nextState = pruneSessionGroups(nextState, openTabs.map(tab => tab.id));
+  nextState = pruneSessionGroups(nextState, getOpenTabIdsForSessionPruning());
   return saveSessionGroups(nextState);
 }
 
@@ -2378,7 +2416,7 @@ async function closeTabsByUrls(urls) {
     }
   }
 
-  const allTabs = await chrome.tabs.query({});
+  const allTabs = await queryTabsForDashboardWindow();
   const toClose = allTabs
     .filter(tab => {
       const tabUrl = getTabCanonicalUrl(tab);
@@ -2392,7 +2430,7 @@ async function closeTabsByUrls(urls) {
 
   if (toClose.length > 0) await chrome.tabs.remove(toClose);
   await fetchOpenTabs();
-  await loadSessionGroups(openTabs.map(tab => tab.id));
+  await loadSessionGroups(getOpenTabIdsForSessionPruning());
 }
 
 /**
@@ -2404,11 +2442,11 @@ async function closeTabsByUrls(urls) {
 async function closeTabsExact(urls) {
   if (!urls || urls.length === 0) return;
   const urlSet = new Set(urls.map(url => runtimeGetCanonicalTabUrl ? runtimeGetCanonicalTabUrl(url) : url));
-  const allTabs = await chrome.tabs.query({});
+  const allTabs = await queryTabsForDashboardWindow();
   const toClose = allTabs.filter(t => urlSet.has(getTabCanonicalUrl(t))).map(t => t.id);
   if (toClose.length > 0) await chrome.tabs.remove(toClose);
   await fetchOpenTabs();
-  await loadSessionGroups(openTabs.map(tab => tab.id));
+  await loadSessionGroups(getOpenTabIdsForSessionPruning());
 }
 
 /**
@@ -2434,8 +2472,7 @@ async function focusTab(url, tabId = null) {
     } catch { /* fall back to URL matching */ }
   }
 
-  const allTabs = await chrome.tabs.query({});
-  const currentWindow = await chrome.windows.getCurrent();
+  const allTabs = await queryTabsForDashboardWindow();
   const targetUrl = runtimeGetCanonicalTabUrl ? runtimeGetCanonicalTabUrl(url || '') : url;
 
   // Try exact URL match first
@@ -2454,8 +2491,7 @@ async function focusTab(url, tabId = null) {
 
   if (matches.length === 0) return false;
 
-  // Prefer a match in a different window so it actually switches windows
-  const match = matches.find(t => t.windowId !== currentWindow.id) || matches[0];
+  const match = matches.find(t => t.active) || matches[0];
   await chrome.tabs.update(match.id, { active: true });
   await chrome.windows.update(match.windowId, { focused: true });
   if (typeof syncChromeTabGroupExpansionForTab === 'function') {
@@ -2502,7 +2538,7 @@ async function runDefaultSearch(query) {
  * keepOne=false → close all copies.
  */
 async function closeDuplicateTabs(urls, keepOne = true) {
-  const allTabs = await chrome.tabs.query({});
+  const allTabs = await queryTabsForDashboardWindow();
   const toClose = [];
 
   for (const url of urls) {
@@ -2520,7 +2556,7 @@ async function closeDuplicateTabs(urls, keepOne = true) {
 
   if (toClose.length > 0) await chrome.tabs.remove(toClose);
   await fetchOpenTabs();
-  await loadSessionGroups(openTabs.map(tab => tab.id));
+  await loadSessionGroups(getOpenTabIdsForSessionPruning());
 }
 
 /**
@@ -2531,7 +2567,7 @@ async function closeDuplicateTabs(urls, keepOne = true) {
 async function closeTabOutDupes() {
   const newtabUrl = window.location.href;
 
-  const allTabs = await chrome.tabs.query({});
+  const allTabs = await queryTabsForDashboardWindow();
   const currentWindow = await chrome.windows.getCurrent();
   const tabOutTabs = allTabs.filter(t =>
     t.url === newtabUrl || t.url === 'chrome://newtab/'
@@ -3333,7 +3369,7 @@ async function renderStaticDashboard() {
   // --- Fetch tabs ---
   await fetchOpenTabs();
   const realTabs = getRealTabs();
-  await loadSessionGroups(realTabs.map(tab => tab.id));
+  await loadSessionGroups(getOpenTabIdsForSessionPruning());
   await loadGroupOrder();
   await loadGroupLabelOverrides();
   await buildDomainGroups(realTabs);
@@ -3680,7 +3716,7 @@ document.addEventListener('click', async (e) => {
     // and duplicate pages cannot close the wrong tab.
     await removeOpenTabByIdOrUrl(tabId, tabUrl);
     await fetchOpenTabs();
-    await loadSessionGroups(openTabs.map(tab => tab.id));
+    await loadSessionGroups(getOpenTabIdsForSessionPruning());
 
     playCloseSound();
 
@@ -3748,7 +3784,7 @@ document.addEventListener('click', async (e) => {
     }
 
     await fetchOpenTabs();
-    await loadSessionGroups(openTabs.map(tab => tab.id));
+    await loadSessionGroups(getOpenTabIdsForSessionPruning());
     await renderDashboard();
 
     showToast(runtimeT ? runtimeT('toastTabDiscarded') : 'Tab sleeping');
@@ -3854,7 +3890,7 @@ document.addEventListener('click', async (e) => {
     }
 
     await fetchOpenTabs();
-    await loadSessionGroups(openTabs.map(tab => tab.id));
+    await loadSessionGroups(getOpenTabIdsForSessionPruning());
     await renderDashboard();
 
     showToast(runtimeT
@@ -3878,7 +3914,7 @@ document.addEventListener('click', async (e) => {
     }
 
     await fetchOpenTabs();
-    await loadSessionGroups(openTabs.map(tab => tab.id));
+    await loadSessionGroups(getOpenTabIdsForSessionPruning());
     await renderDashboard();
 
     showToast(runtimeT
@@ -4646,6 +4682,7 @@ async function initializeDashboardRuntime() {
   primeEntryAnimations();
   const currentTab = await resolveCurrentDashboardTab();
   currentDashboardTabId = currentTab?.id ?? null;
+  currentDashboardWindowId = currentTab?.windowId ?? null;
   dashboardStartupTabChangeIgnoreUntil = Date.now() + 2000;
   window.__suppressAutoRefreshUntil = Math.max(
     window.__suppressAutoRefreshUntil || 0,
@@ -4660,7 +4697,7 @@ async function initializeDashboardRuntime() {
   if (chromeTabGroupsEnabled) {
     await fetchOpenTabs();
     const realTabs = getRealTabs();
-    await loadSessionGroups(realTabs.map(tab => tab.id));
+    await loadSessionGroups(getOpenTabIdsForSessionPruning());
     if (shouldImportChromeGroupsIntoSessionState()) {
       const importedCount = await importChromeNativeGroupsIntoSessionGroups();
       if (typeof setImportMode === 'function') setImportMode(importedCount > 0);

--- a/extension/dashboard-runtime.js
+++ b/extension/dashboard-runtime.js
@@ -752,11 +752,14 @@ function getOpenTabIdsForSessionPruning() {
 }
 
 async function queryTabsForDashboardWindow() {
-  const tabs = await chrome.tabs.query({});
   const currentWindowId = await getDashboardWindowIdForOpenTabs();
-  return currentWindowId == null
-    ? tabs
-    : tabs.filter(tab => tab.windowId === currentWindowId);
+  if (currentWindowId == null) return chrome.tabs.query({});
+
+  try {
+    return await chrome.tabs.query({ windowId: currentWindowId });
+  } catch {
+    return chrome.tabs.query({});
+  }
 }
 
 async function loadSessionGroups(openTabIds = []) {
@@ -1094,8 +1097,6 @@ async function getCurrentWindowId() {
 }
 
 async function getDashboardWindowIdForOpenTabs() {
-  if (currentDashboardWindowId != null) return currentDashboardWindowId;
-
   const currentTab = await resolveCurrentDashboardTab();
   if (currentTab?.windowId != null) {
     currentDashboardWindowId = currentTab.windowId;

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Tab Harbor",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A new tab dashboard for organizing open tabs, quick links, todos, and saved tab sessions in one calm workspace.",
   "permissions": ["tabs", "storage", "search", "clipboardRead", "tabGroups", "favicon"],
   "chrome_url_overrides": { "newtab": "index.html" },

--- a/extension/ui-regression.test.js
+++ b/extension/ui-regression.test.js
@@ -192,6 +192,21 @@ test('tab sessions close selected tabs by id after storage save instead of fuzzy
   assert.doesNotMatch(runtimeJs, /closeTabsByUrls\(selected/);
 });
 
+test('new tab dashboard scopes visible open tabs to its own browser window', () => {
+  assert.match(runtimeJs, /let currentDashboardWindowId = null;/);
+  assert.match(runtimeJs, /let allOpenTabIds = \[\];/);
+  assert.match(runtimeJs, /const visibleTabs = currentWindowId == null\s*\?\s*tabs\s*:\s*tabs\.filter\(t => t\.windowId === currentWindowId\);/);
+  assert.match(runtimeJs, /openTabs = visibleTabs\.map\(t =>/);
+  assert.match(runtimeJs, /function getOpenTabIdsForSessionPruning\(\)/);
+  assert.match(runtimeJs, /async function queryTabsForDashboardWindow\(\)/);
+  assert.match(runtimeJs, /await loadSessionGroups\(getOpenTabIdsForSessionPruning\(\)\)/);
+  assert.match(runtimeJs, /async function closeTabsByUrls\(urls\) \{[\s\S]*const allTabs = await queryTabsForDashboardWindow\(\);/);
+  assert.match(runtimeJs, /async function closeTabsExact\(urls\) \{[\s\S]*const allTabs = await queryTabsForDashboardWindow\(\);/);
+  assert.match(runtimeJs, /async function closeDuplicateTabs\(urls, keepOne = true\) \{[\s\S]*const allTabs = await queryTabsForDashboardWindow\(\);/);
+  assert.doesNotMatch(runtimeJs, /await loadSessionGroups\(openTabs\.map\(tab => tab\.id\)\)/);
+  assert.doesNotMatch(runtimeJs, /await loadSessionGroups\(realTabs\.map\(tab => tab\.id\)\)/);
+});
+
 test('tab chips no longer render move-to-group controls', () => {
   const css = fs.readFileSync(path.join(__dirname, 'style.css'), 'utf8');
 

--- a/extension/ui-regression.test.js
+++ b/extension/ui-regression.test.js
@@ -198,7 +198,8 @@ test('new tab dashboard scopes visible open tabs to its own browser window', () 
   assert.match(runtimeJs, /const visibleTabs = currentWindowId == null\s*\?\s*tabs\s*:\s*tabs\.filter\(t => t\.windowId === currentWindowId\);/);
   assert.match(runtimeJs, /openTabs = visibleTabs\.map\(t =>/);
   assert.match(runtimeJs, /function getOpenTabIdsForSessionPruning\(\)/);
-  assert.match(runtimeJs, /async function queryTabsForDashboardWindow\(\)/);
+  assert.match(runtimeJs, /async function queryTabsForDashboardWindow\(\) \{[\s\S]*chrome\.tabs\.query\(\{\s*windowId: currentWindowId\s*\}\)/);
+  assert.doesNotMatch(runtimeJs, /if \(currentDashboardWindowId != null\) return currentDashboardWindowId;/);
   assert.match(runtimeJs, /await loadSessionGroups\(getOpenTabIdsForSessionPruning\(\)\)/);
   assert.match(runtimeJs, /async function closeTabsByUrls\(urls\) \{[\s\S]*const allTabs = await queryTabsForDashboardWindow\(\);/);
   assert.match(runtimeJs, /async function closeTabsExact\(urls\) \{[\s\S]*const allTabs = await queryTabsForDashboardWindow\(\);/);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Tab Harbor",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A new tab dashboard for organizing open tabs, quick links, todos, and saved tab sessions in one calm workspace.",
   "permissions": ["tabs", "storage", "search", "clipboardRead", "tabGroups", "favicon"],
   "chrome_url_overrides": { "newtab": "extension/index.html" },


### PR DESCRIPTION
## Summary
- 将新标签页 dashboard 的可见标签范围限定为当前浏览器窗口，避免不同窗口互相同步显示。
- 将关闭、去重、URL fallback 等从当前页面触发的标签操作收窄到当前窗口，同时保留全局 tab id 做 session assignment 清理，避免误删其他窗口分组状态。
- 调整 Chrome 原生标签组同步，只清理本次同步涉及窗口中的过期映射，避免一个窗口刷新时拆掉其他窗口分组。

## Test Plan
- [x] `node --test extension/*.test.js`
- [x] `git diff --check`
- [x] `node --check extension/dashboard-runtime.js`
- [x] `node --check extension/chrome-tab-groups-sync.js`

## Notes
- 当前分支还包含已有提交 `chore(release): 发布 1.1.1`，因此 PR diff 中会包含 manifest 版本号变更。